### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Global Code Owners
+* @DataDog/synthetics-worker
+
+# Documentation
+*README.md @DataDog/documentation @DataDog/synthetics-worker


### PR DESCRIPTION
Code owners need to be added to automatically assign teams as reviewers for the pull requests.