### PR TITLE
Ensure js file exists before running a mocked task

### DIFF
--- a/SyntheticsRunTestsTask/__tests__/fixtures.ts
+++ b/SyntheticsRunTestsTask/__tests__/fixtures.ts
@@ -3,6 +3,8 @@ import {join} from 'path'
 import {synthetics} from '@datadog/datadog-ci'
 import {MockTestRunner} from 'azure-pipelines-task-lib/mock-test'
 
+import * as fs from 'fs'
+
 export const BASE_CONFIG: synthetics.CommandConfig = {
   apiKey: '',
   appKey: '',
@@ -44,6 +46,11 @@ export const CUSTOM_PUBLIC_IDS = ['public_id1', 'public_id2', 'public_id3']
 
 const runMockedTask = (mockName: string): MockTestRunner => {
   const file = join(__dirname, 'mocks', `${mockName}.js`)
+
+  if (!fs.existsSync(file)) {
+    throw Error(`The mocked task file does not exist: mocks/${mockName}.js\n` + 'Did you forget to run `yarn build`?')
+  }
+
   const task = new MockTestRunner(file)
   task.run()
   // Warnings usually come from `mockery`, and can be useful to spot mocking issues.


### PR DESCRIPTION
If you forget to run `yarn build` before `yarn test` in a clean repository without any compiled files, you'll have errors like:

```
    expect(received).toContainEqual(expected) // deep equality

    Expected value: [Anything, {"apiKey": "xxx", "appKey": "yyy", "configPath": "datadog-ci.json", "datadogSite": "datadoghq.eu", "failOnCriticalErrors": false, "failOnTimeout": false, "files": ["{,!(node_modules)/**/}*.synthetics.json"], "global": {}, "locations": [], "pollingTimeout": 120000, "proxy": {"protocol": "http"}, "publicIds": ["public_id1", "public_id2", "public_id3"], "subdomain": "myorg", "tunnel": false, "variableStrings": []}]
    Received array: []

       99 |     const logs: unknown[] = spyLogs.map(log => JSON.parse(log.replace(prefixMatcher, '')))
      100 |
    > 101 |     expect(logs).toContainEqual(args)
```

or

```
    Expected: false
    Received: true

      32 |     const task = runMockTaskServiceConnectionMisconfigured()
      33 |
    > 34 |     expect(task.succeeded).toBe(false)
```

Apparently, [azure-pipelines-task-lib](https://github.com/microsoft/azure-pipelines-task-lib) doesn't do the correct check ([here](https://github.com/microsoft/azure-pipelines-task-lib/blob/ee582bc9b6c7ed2749929b0d66bc34af831e0eea/node/mock-test.ts#L68-L81)) to know if the node process crashed.