### PR TITLE
[dep] `SyntheticsRunTestsTask`: Node10 legacy support

### DIFF
--- a/SyntheticsRunTestsTask/task.json
+++ b/SyntheticsRunTestsTask/task.json
@@ -105,6 +105,9 @@
     }
   ],
   "execution": {
+    "Node10": {
+      "target": "task.node10.js"
+    },
     "Node16": {
       "target": "task.js"
     }

--- a/SyntheticsRunTestsTask/task.node10.ts
+++ b/SyntheticsRunTestsTask/task.node10.ts
@@ -1,0 +1,9 @@
+import {logError, LogType} from 'azure-pipelines-tasks-packaging-common/util'
+
+logError(
+  'Node 10 support for SyntheticsRunTestsTask is deprecated, please upgrade the agent version.\n' +
+    'See https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/agents#agent-version-and-upgrades',
+  LogType.warning
+)
+
+require('./task')


### PR DESCRIPTION
- **Based on https://github.com/DataDog/datadog-ci-azure-devops/pull/27**

(Re)Add support for `Node10`execution handler flagged as legacy, the task is still executed but a warning is emitted.

The warning will show up in the pipeline and the task logs:
![image](https://user-images.githubusercontent.com/19409477/199542880-ea242e06-e785-476c-a3bd-d899705565d4.png)


This will be mentioned in the Github release notes.