### PR TITLE
Use `utils` exposed by datadog-ci

### DIFF
--- a/SyntheticsRunTestsTask/__tests__/mocks/api-keys.ts
+++ b/SyntheticsRunTestsTask/__tests__/mocks/api-keys.ts
@@ -1,6 +1,6 @@
 import {join} from 'path'
 
-import {synthetics} from '@datadog/datadog-ci'
+import {synthetics, utils} from '@datadog/datadog-ci'
 import {TaskMockRunner} from 'azure-pipelines-task-lib/mock-run'
 
 import {BASE_INPUTS, CUSTOM_PUBLIC_IDS, EMPTY_SUMMARY, setupWarnSpy, spyLog} from '../fixtures'
@@ -15,6 +15,7 @@ mockRunner.setInput('appKey', BASE_INPUTS.appKey)
 mockRunner.setInput('publicIds', CUSTOM_PUBLIC_IDS.join(', '))
 
 mockRunner.registerMock('@datadog/datadog-ci', {
+  utils,
   synthetics: {
     ...synthetics,
     executeTests: async (

--- a/SyntheticsRunTestsTask/__tests__/mocks/junit-report.ts
+++ b/SyntheticsRunTestsTask/__tests__/mocks/junit-report.ts
@@ -1,6 +1,6 @@
 import {join} from 'path'
 
-import {synthetics} from '@datadog/datadog-ci'
+import {synthetics, utils} from '@datadog/datadog-ci'
 import {TaskMockRunner} from 'azure-pipelines-task-lib/mock-run'
 
 import {BASE_INPUTS, CUSTOM_PUBLIC_IDS, EMPTY_SUMMARY, setupWarnSpy, spyLog} from '../fixtures'
@@ -16,6 +16,7 @@ mockRunner.setInput('publicIds', CUSTOM_PUBLIC_IDS.join(', '))
 mockRunner.setInput('jUnitReport', 'reports/TEST-1.xml')
 
 mockRunner.registerMock('@datadog/datadog-ci', {
+  utils,
   synthetics: {
     ...synthetics,
     executeTests: async (

--- a/SyntheticsRunTestsTask/__tests__/mocks/service-connection-env-vars.ts
+++ b/SyntheticsRunTestsTask/__tests__/mocks/service-connection-env-vars.ts
@@ -1,6 +1,6 @@
 import {join} from 'path'
 
-import {synthetics} from '@datadog/datadog-ci'
+import {synthetics, utils} from '@datadog/datadog-ci'
 import {TaskMockRunner} from 'azure-pipelines-task-lib/mock-run'
 
 import {
@@ -29,6 +29,7 @@ process.env[`ENDPOINT_AUTH_PARAMETER_${CONNECTED_SERVICE_NAME.toLocaleUpperCase(
 process.env[`ENDPOINT_DATA_${CONNECTED_SERVICE_NAME}_SUBDOMAIN`] = CUSTOM_SUBDOMAIN
 
 mockRunner.registerMock('@datadog/datadog-ci', {
+  utils,
   synthetics: {
     ...synthetics,
     executeTests: async (

--- a/SyntheticsRunTestsTask/__tests__/mocks/service-connection.ts
+++ b/SyntheticsRunTestsTask/__tests__/mocks/service-connection.ts
@@ -1,6 +1,6 @@
 import {join} from 'path'
 
-import {synthetics} from '@datadog/datadog-ci'
+import {synthetics, utils} from '@datadog/datadog-ci'
 import {TaskMockRunner} from 'azure-pipelines-task-lib/mock-run'
 import type task from 'azure-pipelines-task-lib/task'
 
@@ -44,6 +44,7 @@ taskMock.getEndpointAuthorizationParameterRequired = (_id: string, key: string) 
 mockRunner.registerMock('azure-pipelines-task-lib/mock-task', taskMock)
 
 mockRunner.registerMock('@datadog/datadog-ci', {
+  utils,
   synthetics: {
     ...synthetics,
     executeTests: async (

--- a/SyntheticsRunTestsTask/resolve-config.ts
+++ b/SyntheticsRunTestsTask/resolve-config.ts
@@ -4,7 +4,7 @@ import * as task from 'azure-pipelines-task-lib/task'
 import {synthetics, utils} from '@datadog/datadog-ci'
 import deepExtend from 'deep-extend'
 
-import {parseMultiline, removeUndefinedValues} from './utils'
+import {parseMultiline} from './utils'
 import {Reporter} from '@datadog/datadog-ci/dist/commands/synthetics'
 
 const DEFAULT_CONFIG: synthetics.CommandConfig = {
@@ -112,7 +112,7 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
   // Override with the task's inputs
   config = deepExtend(
     config,
-    removeUndefinedValues({
+    utils.removeUndefinedValues({
       apiKey,
       appKey,
       configPath,
@@ -123,7 +123,7 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
       testSearchQuery,
       global: deepExtend(
         config.global,
-        removeUndefinedValues({
+        utils.removeUndefinedValues({
           variables: synthetics.utils.parseVariablesFromCli(variableStrings, reporter.log.bind(reporter)),
         })
       ),

--- a/SyntheticsRunTestsTask/utils.ts
+++ b/SyntheticsRunTestsTask/utils.ts
@@ -1,13 +1,3 @@
-export const removeUndefinedValues = <T extends {[key: string]: unknown}>(object: T): T => {
-  const newObject = {...object}
-  for (const [key, value] of Object.entries(newObject)) {
-    if (value === undefined) {
-      delete newObject[key]
-    }
-  }
-  return newObject
-}
-
 export const parseMultiline = (value: string | undefined): string[] | undefined => {
   return value?.split(/,|\n/).map((variableString: string) => variableString.trim())
 }


### PR DESCRIPTION
- https://github.com/DataDog/datadog-ci-azure-devops/pull/41
- https://github.com/DataDog/datadog-ci-azure-devops/pull/42
- https://github.com/DataDog/datadog-ci-azure-devops/pull/44 ←
---

This PR replaces the local implementation of `removeUndefinedValues` with an import of `datadog-ci`'s one.

It also updates the test mocks accordingly, and adds some comments in `fixtures.ts`.