### PR TITLE
[package] Exclude `.yarn` folder

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,6 +66,7 @@ stages:
                 yarn install --immutable
                 yarn build
                 yarn workspaces focus --production
+                rm -rf .yarn/
 
           - task: PackageAzureDevOpsExtension@3
             displayName: Package Datadog CI extension


### PR DESCRIPTION
Following the migration to Yarn 3 (#42), the "Release DEV Publish DEV version" [job started failing](https://datadog-ci.visualstudio.com/Datadog%20CI%20Azure%20DevOps%20Extension/_build/results?buildId=518&view=logs&j=8a5e36fb-d34d-5540-eed9-70d1ef2de729&t=afe13ce5-d1dd-5c0d-ab96-b4c54c0d0d39) with:

> error: Extension package is malformed/corrupted
>
> ##[error]tfx failed with error: Error: The process '/opt/hostedtoolcache/tfx/0.12.0/x64/bin/tfx' failed with exit code 255

A related issue exists on the repository for the `tfx` CLI: https://github.com/Microsoft/tfs-cli/issues/133
But the issue is still open.

So, since we can't ignore files with the CLI we need to remove the `.yarn` folder (contains cache for the `node_modules`) before packaging the `.vsix` file.