### PR TITLE
Remove superfluous dependency

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -6,7 +6,6 @@
 @typescript-eslint/parser,dev,BSD 2-Clause License, Copyright JS Foundation and other contributors
 azure-pipelines-task-lib,import,MIT,Copyright (c) Microsoft Corporation
 azure-pipelines-tasks-packaging-common,import,MIT,Copyright (c) Microsoft Corporation
-clipanion,import,MIT,Copyright (c) 2019 Mael Nison
 deep-extend,import,MIT,"Copyright (c) 2013-2018, Viacheslav Lotsmanov"
 eslint,dev,MIT,Copyright OpenJS Foundation and other contributors
 eslint-plugin-jest,dev,MIT,Copyright (c) 2018 Jonathan Kim

--- a/SyntheticsRunTestsTask/package.json
+++ b/SyntheticsRunTestsTask/package.json
@@ -32,7 +32,6 @@
     "@datadog/datadog-ci": "^2.9.1",
     "azure-pipelines-task-lib": "^3.1.1",
     "azure-pipelines-tasks-packaging-common": "^2.198.1",
-    "clipanion": "^3.0.1",
     "deep-extend": "^0.6.0",
     "vss-web-extension-sdk": "^5.141.0"
   },

--- a/SyntheticsRunTestsTask/resolve-config.ts
+++ b/SyntheticsRunTestsTask/resolve-config.ts
@@ -1,4 +1,3 @@
-import {BaseContext} from 'clipanion'
 import * as task from 'azure-pipelines-task-lib/task'
 
 import {synthetics, utils} from '@datadog/datadog-ci'
@@ -136,17 +135,11 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
 }
 
 export const getReporter = (): synthetics.MainReporter => {
-  const context: BaseContext = {
-    stdin: process.stdin,
-    stdout: process.stdout,
-    stderr: process.stderr,
-  }
-
-  const reporters: synthetics.Reporter[] = [new synthetics.DefaultReporter({context})]
+  const reporters: synthetics.Reporter[] = [new synthetics.DefaultReporter({context: process})]
 
   const jUnitReportFilename = task.getInput('jUnitReport')
   if (jUnitReportFilename) {
-    reporters.push(new synthetics.JUnitReporter({context, jUnitReport: jUnitReportFilename}))
+    reporters.push(new synthetics.JUnitReporter({context: process, jUnitReport: jUnitReportFilename}))
   }
 
   return synthetics.utils.getReporter(reporters)

--- a/SyntheticsRunTestsTask/yarn.lock
+++ b/SyntheticsRunTestsTask/yarn.lock
@@ -3057,17 +3057,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clipanion@npm:^3.0.1":
-  version: 3.1.0
-  resolution: "clipanion@npm:3.1.0"
-  dependencies:
-    typanion: ^3.3.1
-  peerDependencies:
-    typanion: "*"
-  checksum: bf350082e8953c697cfe35262845700012bdeb1cc490f81cd17de2fe985c8861750164509795ad95d3ee6a2b3742a1d5c6394cdf0f3ff4c4d24173a9fec3418e
-  languageName: node
-  linkType: hard
-
 "cliui@npm:^7.0.2":
   version: 7.0.4
   resolution: "cliui@npm:7.0.4"
@@ -6997,7 +6986,6 @@ __metadata:
     "@typescript-eslint/parser": ^4.33.0
     azure-pipelines-task-lib: ^3.1.1
     azure-pipelines-tasks-packaging-common: ^2.198.1
-    clipanion: ^3.0.1
     deep-extend: ^0.6.0
     eslint: ^7.32.0
     eslint-plugin-jest: ^24.4.2
@@ -7237,13 +7225,6 @@ __metadata:
   version: 0.14.5
   resolution: "tweetnacl@npm:0.14.5"
   checksum: 6061daba1724f59473d99a7bb82e13f211cdf6e31315510ae9656fefd4779851cb927adad90f3b488c8ed77c106adc0421ea8055f6f976ff21b27c5c4e918487
-  languageName: node
-  linkType: hard
-
-"typanion@npm:^3.3.1":
-  version: 3.12.1
-  resolution: "typanion@npm:3.12.1"
-  checksum: a2e26fa216f8a1dbd2ffbaacb75b1e2dc042a0356e9702fba05a968cad95d9f661b24e37f6c6d8c3adad2c8582c99fca4826ff26a2d07cd2ae617ea87e6187eb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- #46 
- #49 ←
---

The `clipanion` dependency was used to import the `BaseContext` interface only.

But we can just do pass `process` directly: `{ context: process}` (we do it [in datadog-ci](https://github.com/DataDog/datadog-ci/blob/e8f18c0030bf54ca6f81e00d58d60cb6718b6194/src/commands/synthetics/run-test.ts#L279)).