### PR TITLE
[dep] Upgrade `vm2` to `3.9.17`

### DIFF
--- a/SyntheticsRunTestsTask/yarn.lock
+++ b/SyntheticsRunTestsTask/yarn.lock
@@ -7448,14 +7448,14 @@ __metadata:
   linkType: hard
 
 "vm2@npm:^3.9.8":
-  version: 3.9.14
-  resolution: "vm2@npm:3.9.14"
+  version: 3.9.17
+  resolution: "vm2@npm:3.9.17"
   dependencies:
     acorn: ^8.7.0
     acorn-walk: ^8.2.0
   bin:
     vm2: bin/vm2
-  checksum: 1ed7481e07ce8e03055101b382bfbf0d725a5c9b9bbe8bf75f71501cb43a6bd22f6a0a151975ff7cea8cad136d47e66d64f0a3248913f6d3ca3c405db12bacc0
+  checksum: 9a03740a40ab2be5e3348a95fb31512da1a3c85318febb07e5299fa103ff05bcd7b6f458211fa38a1281dc27beccd04ff90355fc1d34fe2ee6ca10d0bb8c6f35
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Even after upgrading datadog-ci (for which we fixed the security vulnerabilities), we still have `vm2@3.9.14` in this CI integration:

```
└─ synthetics-test-automation@workspace:.
   └─ @datadog/datadog-ci@npm:2.10.0 (via npm:^2.9.1)
      └─ proxy-agent@npm:5.0.0 (via npm:5.0.0)
         └─ pac-proxy-agent@npm:5.0.0 (via npm:^5.0.0)
            └─ pac-resolver@npm:5.0.1 (via npm:^5.0.0)
               └─ degenerator@npm:3.0.2 (via npm:^3.0.2)
                  └─ vm2@npm:3.9.14 (via npm:^3.9.8)
```

That's because we only updated the `yarn.lock` in datadog-ci, and not the minimum required version in `package.json`.

This PR should fix:
- https://github.com/DataDog/datadog-ci-azure-devops/security/dependabot/5
- https://github.com/DataDog/datadog-ci-azure-devops/security/dependabot/8
- https://github.com/DataDog/datadog-ci-azure-devops/security/dependabot/9