### PR TITLE
Set task result with summary when tests succeed

### DIFF
--- a/SyntheticsRunTestsTask/task.ts
+++ b/SyntheticsRunTestsTask/task.ts
@@ -30,7 +30,9 @@ async function run(): Promise<void> {
 
     const exitReason = synthetics.utils.getExitReason(config, {results})
     if (exitReason !== 'passed') {
-      task.setResult(task.TaskResult.Failed, `Datadog Synthetics tests failed. ${printSummary(summary, config)}`)
+      task.setResult(task.TaskResult.Failed, `Datadog Synthetics tests failed: ${printSummary(summary, config)}`)
+    } else {
+      task.setResult(task.TaskResult.Succeeded, `Datadog Synthetics tests succeeded: ${printSummary(summary, config)}`)
     }
   } catch (error) {
     synthetics.utils.reportExitLogs(reporter, config, {error})


### PR DESCRIPTION
To align with what's done [in the github action](https://github.com/DataDog/synthetics-ci-github-action/blob/bd6bed82af520d41473c4ce4e68bcb9ac4709dff/src/main.ts#L22-L26), this PR also sets the task result to a success with the summary.

