### PR TITLE
[ci] Trigger the E2E pipeline when the main ADO pipeline succeeds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,10 +16,6 @@ parameters:
       - Patch
       - Minor
       - Major
-  - name: performDevRelease
-    displayName: Release DEV Extension
-    type: boolean
-    default: false
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -45,7 +41,8 @@ stages:
   # Build and package .vsix extension file
   - stage: Build
     jobs:
-      - job: Build
+      - job: BuildAndPackage
+        displayName: Build and package
         steps:
           - task: TfxInstaller@3
             displayName: Install TFX CLI
@@ -82,96 +79,53 @@ stages:
             displayName: Publish VSIX artifact
             artifact: $(artifactPath)
 
-  - ${{ if and(eq(parameters.performRelease, false), eq(parameters.performDevRelease, false)) }}:
-      - stage: Test
-        displayName: E2E tests
-        dependsOn: 'Build'
-        jobs:
-          - job: E2E
-            displayName: Cross-platform
-            strategy:
-              matrix:
-                Linux:
-                  imageName: 'ubuntu-latest'
-                Windows:
-                  imageName: 'windows-latest'
-            pool:
-              vmImage: $(imageName)
-            steps:
-              - download: current
-                displayName: Download VSIX artifact
-                artifact: $(artifactPath)
+  # Release a DEV extension. E2E tests will automatically run on it in `e2e.azure-pipelines.yml`
+  - stage: ReleaseDev
+    displayName: Release DEV
+    dependsOn: Build
+    jobs:
+      - job: PublishDev
+        displayName: Publish DEV version
+        steps:
+          - download: current
+            displayName: Download VSIX artifact
+            artifact: $(artifactPath)
 
-              # Extract the extension then run the task directly with node by providing
-              # the inputs through environment variables
-              - task: ExtractFiles@1
-                displayName: Extract VSIX
-                inputs:
-                  archiveFilePatterns: '$(Pipeline.Workspace)/$(artifactPath)/$(packagedTask)'
-                  destinationFolder: 'extracted'
+          - task: TfxInstaller@3
+            displayName: Install TFX CLI
+            inputs:
+              version: 'v0.12.x'
 
-              - task: Bash@3
-                displayName: Run the task
-                inputs:
-                  workingDirectory: 'extracted/SyntheticsRunTestsTask'
-                  targetType: 'inline'
-                  script: |
-                    export INPUT_AUTHENTICATIONTYPE='apiAppKeys'
-                    export INPUT_APIKEY='$(API_KEY)'
-                    export INPUT_APPKEY='$(APP_KEY)'
-                    export INPUT_CONFIGPATH='../../ci/e2e.config.json'
-                    export INPUT_PUBLICIDS='2r9-q7u-4nn,pwd-mwg-3p5'
-                    node task.js
+          - task: QueryAzureDevOpsExtensionVersion@3
+            displayName: Query existing DEV extension version
+            name: 'queryDevVersion'
+            inputs:
+              connectTo: 'VsTeam'
+              connectedServiceName: 'marketplace-service-connection'
+              publisherId: '$(publisherId)'
+              extensionId: '$(extensionId)'
+              extensionTag: '$(devExtensionTag)'
+              versionAction: 'Patch'
 
-  # Release DEV extension on `performDevRelease` or automatically on `main` push
-  - ${{ if or(eq(parameters.performDevRelease, true), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-      - stage: ReleaseDev
-        displayName: Release DEV
-        dependsOn: 'Build'
-        jobs:
-          - job: PublishDev
-            displayName: Publish DEV version
-            steps:
-              - download: current
-                displayName: Download VSIX artifact
-                artifact: $(artifactPath)
-
-              - task: TfxInstaller@3
-                displayName: Install TFX CLI
-                inputs:
-                  version: 'v0.12.x'
-
-              - task: QueryAzureDevOpsExtensionVersion@3
-                displayName: Query existing DEV extension version
-                name: 'queryDevVersion'
-                inputs:
-                  connectTo: 'VsTeam'
-                  connectedServiceName: 'marketplace-service-connection'
-                  publisherId: '$(publisherId)'
-                  extensionId: '$(extensionId)'
-                  extensionTag: '$(devExtensionTag)'
-                  versionAction: 'Patch'
-
-              - task: PublishAzureDevOpsExtension@3
-                displayName: Publish new DEV extension version
-                inputs:
-                  connectTo: 'VsTeam'
-                  connectedServiceName: 'marketplace-service-connection'
-                  fileType: 'vsix'
-                  vsixFile: '$(Pipeline.Workspace)/$(artifactPath)/$(packagedTask)'
-                  extensionTag: '$(devExtensionTag)'
-                  extensionName: '$(extensionName) DEV'
-                  extensionVersion: '$(queryDevVersion.Extension.Version)'
-                  updateTasksId: true
-                  extensionVisibility: 'private'
-                  extensionPricing: 'free'
-                  shareWith: 'datadog-ci'
+          - task: PublishAzureDevOpsExtension@3
+            displayName: Publish new DEV extension version
+            inputs:
+              connectTo: 'VsTeam'
+              connectedServiceName: 'marketplace-service-connection'
+              fileType: 'vsix'
+              vsixFile: '$(Pipeline.Workspace)/$(artifactPath)/$(packagedTask)'
+              extensionTag: '$(devExtensionTag)'
+              extensionName: '$(extensionName) DEV'
+              extensionVersion: '$(queryDevVersion.Extension.Version)'
+              updateTasksId: true
+              extensionVisibility: 'private'
+              extensionPricing: 'free'
+              shareWith: 'datadog-ci'
 
   # Extension public release, only performed on manual runs
   - ${{ if eq(parameters.performRelease, true) }}:
       - stage: Release
-        displayName: Release
-        dependsOn: 'Build'
+        dependsOn: Build
         jobs:
           - job: PublishPublic
             displayName: Publish (public)

--- a/ci/e2e.azure-pipelines.yml
+++ b/ci/e2e.azure-pipelines.yml
@@ -1,7 +1,7 @@
 trigger: none # Disable individual commit runs. https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git?view=azure-devops&tabs=yaml#opting-out-of-ci
 pr: none # Disable PR runs. https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git?view=azure-devops&tabs=yaml#pr-triggers
 
-# Automatically run this E2E pipeline when the main pipeline succeeded.
+# Automatically run this E2E pipeline when the main pipeline succeeds.
 # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/resources?view=azure-devops&tabs=schema#define-a-pipelines-resource
 resources:
   pipelines:

--- a/ci/e2e.azure-pipelines.yml
+++ b/ci/e2e.azure-pipelines.yml
@@ -1,6 +1,14 @@
 trigger: none # Disable individual commit runs. https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git?view=azure-devops&tabs=yaml#opting-out-of-ci
 pr: none # Disable PR runs. https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git?view=azure-devops&tabs=yaml#pr-triggers
 
+# Automatically run this E2E pipeline when the main pipeline succeeded.
+# https://learn.microsoft.com/en-us/azure/devops/pipelines/process/resources?view=azure-devops&tabs=schema#define-a-pipelines-resource
+resources:
+  pipelines:
+    - pipeline: e2e-tests-on-dev-extension
+      source: DataDog.datadog-ci-azure-devops # Name of `azure-pipelines.yml` as shown in the Azure DevOps UI.
+      trigger: true
+
 variables:
   - group: ci-variables
 


### PR DESCRIPTION
This PR automates running **actual E2E tests** on the DEV extension ([defined here](https://github.com/DataDog/datadog-ci-azure-devops/blob/main/ci/e2e.azure-pipelines.yml)).

**Note:** what I will call "custom E2E tests" below is the following part of our main Azure DevOps (ADO) pipeline ([defined here](https://github.com/DataDog/datadog-ci-azure-devops/blob/main/azure-pipelines.yml)). Where we extract the VSIX, define inputs with environment variables and run the task with `node`:

https://github.com/DataDog/datadog-ci-azure-devops/blob/6ba15782b27091926f558214a89c5c355d4d80f2/azure-pipelines.yml#L116-L124

Before:
- Create a PR
- "Custom E2E tests" are run automatically on every commit in the PR
- To run the **actual E2E tests**, you had to:
  1. Manually run the main ADO pipeline with `performDevRelease: true`, which would publish a new patch version of `Datadog.datadog-ci-dev.synthetics-application-testing.SyntheticsRunTests`
  2. Manually run the E2E pipeline, which would use the latest patch of the DEV extension

After:
- Create a PR
- The main ADO pipeline publishes a new patch version of `Datadog.datadog-ci-dev.synthetics-application-testing.SyntheticsRunTests` on every commit in this PR
- The E2E pipeline is triggered automatically when the main ADO pipeline (aka. `DataDog.datadog-ci-azure-devops` in our Azure DevOps UI) succeeds

So this PR also gets rid of the "custom E2E tests", which become useless.