### PR TITLE
Add `pollingTimeout` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Your task can be [simple](#simple-usage) or [complex](#complex-usage).
 | `configPath`         | _optional_  | The global JSON configuration used when launching tests. For more information, see the [example configuration][9]. **Default:** `datadog-ci.json`.                                                                                              |
 | `variables`          | _optional_  | A list of global variables to use for Synthetic tests, separated by new lines or commas. For example: `START_URL=https://example.org,MY_VARIABLE=My title`. **Default:** `[]`.                                                                  |
 | `jUnitReport`        | _optional_  | The filename for a JUnit report if you want to generate one.                                                                                                                                                                                    |
+| `pollingTimeout`     | _optional_  | The duration (in milliseconds) after which the task stops polling for test results. At the CI level, test results completed after this duration are considered failed. **Default:** 30 minutes.                                                 |
 
 
 ## Further reading

--- a/SyntheticsRunTestsTask/__tests__/utils.test.ts
+++ b/SyntheticsRunTestsTask/__tests__/utils.test.ts
@@ -1,0 +1,19 @@
+import {getDefinedInteger} from '../utils'
+
+describe('getDefinedInteger', () => {
+  test('returns undefined if input is not set', async () => {
+    expect(getDefinedInteger(undefined)).toBeUndefined()
+  })
+
+  test('returns undefined if input is an empty value', async () => {
+    expect(getDefinedInteger('')).toBeUndefined()
+  })
+
+  test('throws if input is a float', async () => {
+    expect(() => getDefinedInteger('1.2')).toThrow('1.2 is not an integer')
+  })
+
+  test('returns the value if input is an integer', async () => {
+    expect(getDefinedInteger('1')).toStrictEqual(1)
+  })
+})

--- a/SyntheticsRunTestsTask/__tests__/utils.test.ts
+++ b/SyntheticsRunTestsTask/__tests__/utils.test.ts
@@ -2,18 +2,18 @@ import {getDefinedInteger} from '../utils'
 
 describe('getDefinedInteger', () => {
   test('returns undefined if input is not set', async () => {
-    expect(getDefinedInteger(undefined)).toBeUndefined()
+    expect(getDefinedInteger(undefined, {inputName: ''})).toBeUndefined()
   })
 
   test('returns undefined if input is an empty value', async () => {
-    expect(getDefinedInteger('')).toBeUndefined()
+    expect(getDefinedInteger('', {inputName: ''})).toBeUndefined()
   })
 
   test('throws if input is a float', async () => {
-    expect(() => getDefinedInteger('1.2')).toThrow('1.2 is not an integer')
+    expect(() => getDefinedInteger('1.2', {inputName: ''})).toThrow('1.2 is not an integer')
   })
 
   test('returns the value if input is an integer', async () => {
-    expect(getDefinedInteger('1')).toStrictEqual(1)
+    expect(getDefinedInteger('1', {inputName: ''})).toStrictEqual(1)
   })
 })

--- a/SyntheticsRunTestsTask/resolve-config.ts
+++ b/SyntheticsRunTestsTask/resolve-config.ts
@@ -94,7 +94,7 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
   const files = parseMultiline(task.getInput('files'))
   const testSearchQuery = task.getInput('testSearchQuery')
   const variableStrings = parseMultiline(task.getInput('variables'))
-  const pollingTimeout = getDefinedInteger(task.getInput('pollingTimeout'))
+  const pollingTimeout = getDefinedInteger(task.getInput('pollingTimeout'), {inputName: 'pollingTimeout'})
 
   let config = JSON.parse(JSON.stringify(DEFAULT_CONFIG))
   // Override with file config variables

--- a/SyntheticsRunTestsTask/resolve-config.ts
+++ b/SyntheticsRunTestsTask/resolve-config.ts
@@ -3,7 +3,7 @@ import * as task from 'azure-pipelines-task-lib/task'
 import {synthetics, utils} from '@datadog/datadog-ci'
 import deepExtend from 'deep-extend'
 
-import {parseMultiline} from './utils'
+import {getDefinedInteger, parseMultiline} from './utils'
 
 const DEFAULT_CONFIG: synthetics.CommandConfig = {
   apiKey: '',
@@ -94,6 +94,7 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
   const files = parseMultiline(task.getInput('files'))
   const testSearchQuery = task.getInput('testSearchQuery')
   const variableStrings = parseMultiline(task.getInput('variables'))
+  const pollingTimeout = getDefinedInteger(task.getInput('pollingTimeout'))
 
   let config = JSON.parse(JSON.stringify(DEFAULT_CONFIG))
   // Override with file config variables
@@ -104,7 +105,7 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
     })
   } catch (error) {
     if (configPath) {
-      task.setResult(task.TaskResult.Failed, `Unable to parse config file! Please verify config path : ${configPath}`)
+      task.setResult(task.TaskResult.Failed, `Unable to parse config file! Please verify config path: ${configPath}`)
       throw error
     }
     // Here, if configPath is not present it means that default config file does not exist: in this case it's expected for the task to be silent.
@@ -119,6 +120,7 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
       configPath,
       datadogSite,
       files,
+      pollingTimeout,
       publicIds,
       subdomain,
       testSearchQuery,

--- a/SyntheticsRunTestsTask/task.json
+++ b/SyntheticsRunTestsTask/task.json
@@ -115,7 +115,7 @@
       "type": "int",
       "label": "Polling Timeout",
       "defaultValue": "",
-      "helpMarkDown": "The duration (in milliseconds) after which the orb stops polling for test results."
+      "helpMarkDown": "The duration (in milliseconds) after which the task stops polling for test results."
     }
   ],
   "execution": {

--- a/SyntheticsRunTestsTask/task.json
+++ b/SyntheticsRunTestsTask/task.json
@@ -109,6 +109,13 @@
       "label": "JUnit Report",
       "defaultValue": "",
       "helpMarkDown": "The filename for a JUnit report if you want to generate one."
+    },
+    {
+      "name": "pollingTimeout",
+      "type": "int",
+      "label": "Polling Timeout",
+      "defaultValue": "",
+      "helpMarkDown": "The duration (in milliseconds) after which the orb stops polling for test results."
     }
   ],
   "execution": {

--- a/SyntheticsRunTestsTask/utils.ts
+++ b/SyntheticsRunTestsTask/utils.ts
@@ -1,3 +1,20 @@
+import * as task from 'azure-pipelines-task-lib/task'
+
 export const parseMultiline = (value: string | undefined): string[] | undefined => {
   return value?.split(/,|\n/).map((variableString: string) => variableString.trim())
+}
+
+export const getDefinedInteger = (value: string | undefined): number | undefined => {
+  if (!value) {
+    return undefined
+  }
+
+  const number = parseFloat(value)
+  if (!Number.isInteger(number)) {
+    const error = Error(`${number} is not an integer`)
+    task.setResult(task.TaskResult.Failed, error.message)
+    throw error
+  }
+
+  return number
 }

--- a/SyntheticsRunTestsTask/utils.ts
+++ b/SyntheticsRunTestsTask/utils.ts
@@ -4,14 +4,14 @@ export const parseMultiline = (value: string | undefined): string[] | undefined 
   return value?.split(/,|\n/).map((variableString: string) => variableString.trim())
 }
 
-export const getDefinedInteger = (value: string | undefined): number | undefined => {
+export const getDefinedInteger = (value: string | undefined, {inputName}: {inputName: string}): number | undefined => {
   if (!value) {
     return undefined
   }
 
   const number = parseFloat(value)
   if (!Number.isInteger(number)) {
-    const error = Error(`${number} is not an integer`)
+    const error = Error(`Invalid value for ${inputName}: ${number} is not an integer`)
     task.setResult(task.TaskResult.Failed, error.message)
     throw error
   }


### PR DESCRIPTION
This PR adds a `pollingTimeout` input to be able to set a value of `pollingTimeout` different than the default of 30 minutes ([official documentation](https://docs.datadoghq.com/continuous_testing/cicd_integrations/configuration?tab=npm#global-configuration-file-options)).

This input must be an integer.