### PR TITLE
[ci] Bump github actions with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: 'weekly'


### PR DESCRIPTION
This PR will let dependabot check the versions of the github actions that we use for this repository's internal CI.

When merged, dependabot should be able to detect that this action is outdated for example:

https://github.com/DataDog/datadog-ci-azure-devops/blob/aec3d6e7080c9e40e3b9dc14388714f4cc02883e/.github/workflows/check-license.yml#L13