### PR TITLE
[SYNTH-9893] move polling_timeout input to the global config field

### DIFF
--- a/SyntheticsRunTestsTask/__tests__/fixtures.ts
+++ b/SyntheticsRunTestsTask/__tests__/fixtures.ts
@@ -69,6 +69,9 @@ export const runMockTaskServiceConnectionMisconfigured = (): MockTestRunner => {
 export const runMockTaskJUnitReport = (): MockTestRunner => {
   return runMockedTask('junit-report')
 }
+export const runMockTaskPollingTimeout = (): MockTestRunner => {
+  return runMockedTask('polling-timeout')
+}
 
 // The MockTestRunner runs the task it's given in a separate process, so Jest spies cannot work.
 // As a workaround, we need to log from the task process with `spyLog()` in a mocked function,

--- a/SyntheticsRunTestsTask/__tests__/main.test.ts
+++ b/SyntheticsRunTestsTask/__tests__/main.test.ts
@@ -10,6 +10,7 @@ import {
   expectSpy,
   runMockTaskApiKeys,
   runMockTaskJUnitReport,
+  runMockTaskPollingTimeout,
   runMockTaskServiceConnection,
   runMockTaskServiceConnectionEnvVars,
   runMockTaskServiceConnectionMisconfigured,
@@ -102,5 +103,20 @@ describe('Test suite', () => {
     // Cleaning
     fs.unlinkSync('./reports/TEST-1.xml')
     fs.rmdirSync('./reports')
+  })
+
+  test('pollingTimeout input overrides the default config', () => {
+    const task = runMockTaskPollingTimeout()
+
+    expectSpy(task, synthetics.executeTests).toHaveBeenCalledWith(expect.anything(), {
+      ...BASE_CONFIG,
+      ...BASE_INPUTS,
+      publicIds: CUSTOM_PUBLIC_IDS,
+      global: {pollingTimeout: 3600000},
+    })
+
+    expect(task.succeeded).toBe(true)
+    expect(task.warningIssues.length).toEqual(0)
+    expect(task.errorIssues.length).toEqual(0)
   })
 })

--- a/SyntheticsRunTestsTask/__tests__/mocks/polling-timeout.ts
+++ b/SyntheticsRunTestsTask/__tests__/mocks/polling-timeout.ts
@@ -1,0 +1,34 @@
+import {join} from 'path'
+
+import {synthetics, utils} from '@datadog/datadog-ci'
+import {TaskMockRunner} from 'azure-pipelines-task-lib/mock-run'
+
+import {BASE_INPUTS, CUSTOM_PUBLIC_IDS, EMPTY_SUMMARY, setupWarnSpy, spyLog} from '../fixtures'
+
+setupWarnSpy()
+
+const mockRunner = new TaskMockRunner(join(__dirname, '../..', 'task.js'))
+
+mockRunner.setInput('authenticationType', 'apiAppKeys')
+mockRunner.setInput('apiKey', BASE_INPUTS.apiKey)
+mockRunner.setInput('appKey', BASE_INPUTS.appKey)
+mockRunner.setInput('publicIds', CUSTOM_PUBLIC_IDS.join(', '))
+mockRunner.setInput('pollingTimeout', `${60 * 60 * 1000}`)
+
+mockRunner.registerMock('@datadog/datadog-ci', {
+  utils,
+  synthetics: {
+    ...synthetics,
+    executeTests: async (
+      ...args: Parameters<typeof synthetics.executeTests>
+    ): ReturnType<typeof synthetics.executeTests> => {
+      spyLog(synthetics.executeTests, args)
+      return {
+        results: [],
+        summary: EMPTY_SUMMARY,
+      }
+    },
+  },
+})
+
+mockRunner.run()

--- a/SyntheticsRunTestsTask/resolve-config.ts
+++ b/SyntheticsRunTestsTask/resolve-config.ts
@@ -101,13 +101,13 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
       configPath,
       datadogSite,
       files,
-      pollingTimeout,
       publicIds,
       subdomain,
       testSearchQuery,
       global: deepExtend(
         config.global,
         utils.removeUndefinedValues({
+          pollingTimeout,
           variables: synthetics.utils.parseVariablesFromCli(variableStrings, reporter.log.bind(reporter)),
         })
       ),


### PR DESCRIPTION
This PR moves the `polling_timeout` input from the root of the config to the `global` field of the config, where it's expected by datadog-ci: 
datadog-ci pushes pollingTimeout from root config to global config if pollingTimeout is undefined in the global config
- the implementation: https://github.com/DataDog/datadog-ci/blob/8000318d70fd8af22b0e377b27078762b562efb7/src/commands/synthetics/command.ts#L228
- the test: https://github.com/DataDog/datadog-ci/blob/65ffde5d90474af5930da4c2faf016505b70bff9/src/commands/synthetics/__tests__/cli.test.ts#L173-L186