### PR TITLE
[release:patch] `v0.1.5`

### DIFF
--- a/SyntheticsRunTestsTask/task.json
+++ b/SyntheticsRunTestsTask/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 4
+    "Patch": 5
   },
   "preview": true,
   "instanceNameFormat": "Run Datadog Synthetics CI tests",


### PR DESCRIPTION
# What changed
- [ci] Bump github actions with dependabot in https://github.com/DataDog/datadog-ci-azure-devops/pull/60
- Bump actions/checkout from 2 to 3 in https://github.com/DataDog/datadog-ci-azure-devops/pull/62
- Bump actions/setup-node from 2 to 3 in https://github.com/DataDog/datadog-ci-azure-devops/pull/61

**Full Changelog**: [c5ade97...4d27e10](https://github.com/DataDog/datadog-ci-azure-devops/compare/c5ade97...4d27e10c62188ec1e9444da766728dfd7af2b41a)