### PR TITLE
Add deprecation notice for `SyntheticsRunTests@0`

### DIFF
--- a/SyntheticsRunTestsTask/__tests__/main.test.ts
+++ b/SyntheticsRunTestsTask/__tests__/main.test.ts
@@ -33,7 +33,7 @@ describe('Test suite', () => {
     })
 
     expect(task.succeeded).toBe(true)
-    expect(task.warningIssues.length).toEqual(0)
+    // expect(task.warningIssues.length).toEqual(0)
     expect(task.errorIssues.length).toEqual(0)
   })
 
@@ -41,7 +41,7 @@ describe('Test suite', () => {
     const task = runMockTaskServiceConnectionMisconfigured()
 
     expect(task.succeeded).toBe(false)
-    expect(task.warningIssues.length).toEqual(0)
+    // expect(task.warningIssues.length).toEqual(0)
     expect(task.errorIssues.length).toEqual(2)
     expect(task.errorIssues[0]).toEqual(
       'Missing API or APP keys to initialize datadog-ci! Check your Datadog service connection.'
@@ -71,7 +71,7 @@ describe('Test suite', () => {
     })
 
     expect(task.succeeded).toBe(true)
-    expect(task.warningIssues.length).toEqual(0)
+    // expect(task.warningIssues.length).toEqual(0)
     expect(task.errorIssues.length).toEqual(0)
   })
 
@@ -91,7 +91,7 @@ describe('Test suite', () => {
     })
 
     expect(task.succeeded).toBe(true)
-    expect(task.warningIssues.length).toEqual(0)
+    // expect(task.warningIssues.length).toEqual(0)
     expect(task.errorIssues.length).toEqual(0)
   })
 
@@ -109,7 +109,7 @@ describe('Test suite', () => {
     })
 
     expect(task.succeeded).toBe(true)
-    expect(task.warningIssues.length).toEqual(0)
+    // expect(task.warningIssues.length).toEqual(0)
     expect(task.errorIssues.length).toEqual(0)
 
     expect(fs.existsSync('./reports/TEST-1.xml')).toBe(true)
@@ -134,7 +134,7 @@ describe('Test suite', () => {
     })
 
     expect(task.succeeded).toBe(true)
-    expect(task.warningIssues.length).toEqual(0)
+    // expect(task.warningIssues.length).toEqual(0)
     expect(task.errorIssues.length).toEqual(0)
   })
 })

--- a/SyntheticsRunTestsTask/__tests__/main.test.ts
+++ b/SyntheticsRunTestsTask/__tests__/main.test.ts
@@ -33,7 +33,7 @@ describe('Test suite', () => {
     })
 
     expect(task.succeeded).toBe(true)
-    // expect(task.warningIssues.length).toEqual(0)
+    expect(task.warningIssues).toStrictEqual([expect.stringContaining('The `SyntheticsRunTests@0` task is deprecated')])
     expect(task.errorIssues.length).toEqual(0)
   })
 
@@ -41,7 +41,7 @@ describe('Test suite', () => {
     const task = runMockTaskServiceConnectionMisconfigured()
 
     expect(task.succeeded).toBe(false)
-    // expect(task.warningIssues.length).toEqual(0)
+    expect(task.warningIssues).toStrictEqual([expect.stringContaining('The `SyntheticsRunTests@0` task is deprecated')])
     expect(task.errorIssues.length).toEqual(2)
     expect(task.errorIssues[0]).toEqual(
       'Missing API or APP keys to initialize datadog-ci! Check your Datadog service connection.'
@@ -71,7 +71,7 @@ describe('Test suite', () => {
     })
 
     expect(task.succeeded).toBe(true)
-    // expect(task.warningIssues.length).toEqual(0)
+    expect(task.warningIssues).toStrictEqual([expect.stringContaining('The `SyntheticsRunTests@0` task is deprecated')])
     expect(task.errorIssues.length).toEqual(0)
   })
 
@@ -91,7 +91,7 @@ describe('Test suite', () => {
     })
 
     expect(task.succeeded).toBe(true)
-    // expect(task.warningIssues.length).toEqual(0)
+    expect(task.warningIssues).toStrictEqual([expect.stringContaining('The `SyntheticsRunTests@0` task is deprecated')])
     expect(task.errorIssues.length).toEqual(0)
   })
 
@@ -109,7 +109,7 @@ describe('Test suite', () => {
     })
 
     expect(task.succeeded).toBe(true)
-    // expect(task.warningIssues.length).toEqual(0)
+    expect(task.warningIssues).toStrictEqual([expect.stringContaining('The `SyntheticsRunTests@0` task is deprecated')])
     expect(task.errorIssues.length).toEqual(0)
 
     expect(fs.existsSync('./reports/TEST-1.xml')).toBe(true)
@@ -134,7 +134,7 @@ describe('Test suite', () => {
     })
 
     expect(task.succeeded).toBe(true)
-    // expect(task.warningIssues.length).toEqual(0)
+    expect(task.warningIssues).toStrictEqual([expect.stringContaining('The `SyntheticsRunTests@0` task is deprecated')])
     expect(task.errorIssues.length).toEqual(0)
   })
 })

--- a/SyntheticsRunTestsTask/task.ts
+++ b/SyntheticsRunTestsTask/task.ts
@@ -12,7 +12,7 @@ async function run(): Promise<void> {
 
   logError(
     'The `SyntheticsRunTests@0` task is deprecated, please use `SyntheticsRunTests@1` instead.\n' +
-      'This is NOT a breaking change: we decided to make the task version reflect the extension version.',
+      'This is NOT a breaking change, but an alignment between the task version and the extension version.',
     LogType.warning
   )
 

--- a/SyntheticsRunTestsTask/task.ts
+++ b/SyntheticsRunTestsTask/task.ts
@@ -4,10 +4,13 @@ import * as task from 'azure-pipelines-task-lib/task'
 
 import {getReporter, resolveConfig} from './resolve-config'
 import {synthetics} from '@datadog/datadog-ci'
+import {LogType, logError} from 'azure-pipelines-tasks-packaging-common/util'
 
 async function run(): Promise<void> {
   task.setResourcePath(path.join(__dirname, 'task.json'))
   synthetics.utils.setCiTriggerApp('azure_devops_task')
+
+  logError('Hello this is a deprecation notice. Do I **support Markdown**?', LogType.warning)
 
   const reporter = getReporter()
   const config = await resolveConfig(reporter)

--- a/SyntheticsRunTestsTask/task.ts
+++ b/SyntheticsRunTestsTask/task.ts
@@ -10,7 +10,11 @@ async function run(): Promise<void> {
   task.setResourcePath(path.join(__dirname, 'task.json'))
   synthetics.utils.setCiTriggerApp('azure_devops_task')
 
-  logError('Hello this is a deprecation notice. Do I **support Markdown**?', LogType.warning)
+  logError(
+    'The `SyntheticsRunTests@0` task is deprecated, please use `SyntheticsRunTests@1` instead.\n' +
+      'This is NOT a breaking change: we decided to make the task version reflect the extension version.',
+    LogType.warning
+  )
 
   const reporter = getReporter()
   const config = await resolveConfig(reporter)


### PR DESCRIPTION
- #74 ←
- #76 
---

This PR adds a deprecation notice to the `SyntheticsRunTests@0`, before we upgrade it to `SyntheticsRunTests@1`.

![image](https://github.com/DataDog/datadog-ci-azure-devops/assets/9317502/57da41d0-d49b-4e87-95f5-460fbf78c2f5)
