### PR TITLE
[ci] Use cached `tfx` tool

### DIFF
--- a/.azure-pipelines/main-pipeline.yml
+++ b/.azure-pipelines/main-pipeline.yml
@@ -47,7 +47,7 @@ stages:
           - task: TfxInstaller@4
             displayName: Install TFX CLI
             inputs:
-              version: 'v0.12.0'
+              version: 'v0.15.0'
 
           - task: NodeTool@0
             displayName: Install Node.js
@@ -94,7 +94,7 @@ stages:
           - task: TfxInstaller@4
             displayName: Install TFX CLI
             inputs:
-              version: 'v0.12.0'
+              version: 'v0.15.0'
 
           - task: QueryAzureDevOpsExtensionVersion@4
             displayName: Query existing DEV extension version
@@ -150,7 +150,7 @@ stages:
               - task: TfxInstaller@4
                 displayName: Install TFX CLI
                 inputs:
-                  version: 'v0.12.0'
+                  version: 'v0.15.0'
 
               - task: QueryAzureDevOpsExtensionVersion@4
                 displayName: Query existing extension version

--- a/.azure-pipelines/main-pipeline.yml
+++ b/.azure-pipelines/main-pipeline.yml
@@ -47,7 +47,7 @@ stages:
           - task: TfxInstaller@4
             displayName: Install TFX CLI
             inputs:
-              version: 'v0.12.x'
+              version: 'v0.12.0'
 
           - task: NodeTool@0
             displayName: Install Node.js
@@ -94,7 +94,7 @@ stages:
           - task: TfxInstaller@4
             displayName: Install TFX CLI
             inputs:
-              version: 'v0.12.x'
+              version: 'v0.12.0'
 
           - task: QueryAzureDevOpsExtensionVersion@4
             displayName: Query existing DEV extension version
@@ -150,7 +150,7 @@ stages:
               - task: TfxInstaller@4
                 displayName: Install TFX CLI
                 inputs:
-                  version: 'v0.12.x'
+                  version: 'v0.12.0'
 
               - task: QueryAzureDevOpsExtensionVersion@4
                 displayName: Query existing extension version

--- a/.azure-pipelines/main-pipeline.yml
+++ b/.azure-pipelines/main-pipeline.yml
@@ -128,7 +128,7 @@ stages:
           - task: Bash@3
             displayName: Wait for DEV extension availability
             inputs:
-              filePath: 'ci/poll-extension-availability.sh'
+              filePath: 'ci/poll-dev-extension-availability.sh'
               arguments: |
                 -s "$(SERVICE_URL)" \
                 -t "$(SERVICE_TOKEN)" \

--- a/ci/poll-dev-extension-availability.sh
+++ b/ci/poll-dev-extension-availability.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Query the installed extension until the expected version is available.
+# Query the installed DEV extension until the expected version is available.
 # Inspired from: https://github.com/microsoft/azure-devops-extension-tasks/issues/189#issue-820340124
 
 set -e
@@ -26,6 +26,9 @@ done
 attempts=1
 max=25
 
+# Installed by `TfxInstaller` in the main pipeline.
+tfx=/opt/hostedtoolcache/tfx/0.12.0/x64/bin/tfx
+
 # Build tasks are "contributed" (Microsoft term to say "made available") by Azure DevOps extensions.
 # The contributions of an extension are defined in the `contributions` section of `vss-extension.json`.
 #
@@ -44,7 +47,7 @@ max=25
 # In the response, there also is a `version` field which is the version of the TASK, but it's an object (e.g. `{ major: 1, minor: 0, patch: 0 }`) which is hard to compare with a string.
 # Since [bumping both the extension and the task is required for an update to occur][1], polling on the extension version is the same as polling on the task version.
 #
-# Also, the extension version is the only one that we already know in our pipeline, thanks to the `QueryAzureDevOpsExtensionVersion` task.
+# The extension version is the only one that we already know in our pipeline, thanks to the `QueryAzureDevOpsExtensionVersion` task.
 # The task version is bumped automatically by `PublishAzureDevOpsExtension` (thanks to `updateTasksVersion: true`) so we can't easily find its new value.
 #
 # [1]: https://github.com/MicrosoftDocs/azure-devops-docs/blob/f39ae7a04f3e124361eee19a84d853ec22c31e99/docs/extend/develop/add-build-task.md?plain=1#L427
@@ -53,7 +56,7 @@ until [ $attempts -gt $max ];
 do
     # List all the build tasks that are available. (e.g. `TfxInstaller`, `Bash`, etc.)
     # Some of them are contributed by Azure DevOps extensions installed in the organization (e.g. `SyntheticsRunTests`).
-    tasks=$(npx tfx-cli build tasks list --authType pat --service-url $SERVICE_URL -t $SERVICE_TOKEN --no-color --json)
+    tasks=$($tfx build tasks list --authType pat --service-url $SERVICE_URL -t $SERVICE_TOKEN --no-color --json)
 
     # Get the current version for the contribution that we are polling.
     current_contribution_version=$(echo $tasks | jq -r ".[] | select(.contributionIdentifier == \"$CONTRIBUTION_IDENTIFIER\") | .contributionVersion")

--- a/ci/poll-dev-extension-availability.sh
+++ b/ci/poll-dev-extension-availability.sh
@@ -27,7 +27,7 @@ attempts=1
 max=25
 
 # Installed by `TfxInstaller` in the main pipeline.
-tfx=/opt/hostedtoolcache/tfx/0.12.0/x64/bin/tfx
+tfx=/opt/hostedtoolcache/tfx/0.15.0/x64/bin/tfx
 
 # Build tasks are "contributed" (Microsoft term to say "made available") by Azure DevOps extensions.
 # The contributions of an extension are defined in the `contributions` section of `vss-extension.json`.


### PR DESCRIPTION
Since we were using `npx tfx-cli`, this tool was downloaded again although it was already there on the disk, since it's downloaded with this task:

https://github.com/DataDog/datadog-ci-azure-devops/blob/26080d5be4b11e779937edb605c33368b422582a/.azure-pipelines/main-pipeline.yml#L150-L153

Downloading this tool with `npm` was showing useless warnings, which now don't appear anymore.

**Before:**

```
/usr/bin/bash /home/vsts/work/_temp/d605dd96-ff78-4f86-abf9-8b7c321e0b55.sh
npm WARN exec The following package was not found and will be installed: tfx-cli@0.15.0
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
Installed version is 0.0.139, waiting 1 seconds for 0.0.140 to become available...
Installed version is 0.0.139, waiting 2 seconds for 0.0.140 to become available...
Installed version is 0.0.139, waiting 3 seconds for 0.0.140 to become available...
Installed version is 0.0.139, waiting 4 seconds for 0.0.140 to become available...
Installed version is 0.0.139, waiting 5 seconds for 0.0.140 to become available...
Installed version is 0.0.139, waiting 6 seconds for 0.0.140 to become available...
Installed version is 0.0.139, waiting 7 seconds for 0.0.140 to become available...
Installed version is 0.0.139, waiting 8 seconds for 0.0.140 to become available...
Installed version is 0.0.139, waiting 9 seconds for 0.0.140 to become available...
Found installed version 0.0.140 for Datadog.datadog-ci-dev.synthetics-application-testing
Finishing: Wait for DEV extension availability
```

**After:**
```
/usr/bin/bash /home/vsts/work/_temp/e730fc5b-21b3-427f-adb2-3eacac2a928c.sh
Installed version is 0.0.140, waiting 1 seconds for 0.0.141 to become available...
Installed version is 0.0.140, waiting 2 seconds for 0.0.141 to become available...
Installed version is 0.0.140, waiting 3 seconds for 0.0.141 to become available...
Installed version is 0.0.140, waiting 4 seconds for 0.0.141 to become available...
Installed version is 0.0.140, waiting 5 seconds for 0.0.141 to become available...
Installed version is 0.0.140, waiting 6 seconds for 0.0.141 to become available...
Installed version is 0.0.140, waiting 7 seconds for 0.0.141 to become available...
Installed version is 0.0.140, waiting 8 seconds for 0.0.141 to become available...
Found installed version 0.0.141 for Datadog.datadog-ci-dev.synthetics-application-testing
Finishing: Wait for DEV extension availability
```

This PR also updates the [`tfx-cli` tool](https://www.npmjs.com/package/tfx-cli) we use from `0.12.0` to `0.15.0`.
Here are the changes that were made between those versions: https://github.com/microsoft/tfs-cli/compare/5d20401b1886e8e612bc0c36b6ab5d20f52d88f0...59d2330c2e586a40cb014ae5b4e02814f5193fc1