### PR TITLE
Release `v1.5.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,14 @@ Your task can be [simple](#simple-usage) or [complex](#complex-usage).
 
 ## Simple usage
 
+> **Note**: We recently changed the major version of the task from `SyntheticsRunTests@0` to `SyntheticsRunTests@1`.
+>
+> This is **NOT a breaking change**, but an alignment between the task version and the extension version.
+
 ### Example task using public IDs
 
 ```yaml
-- task: SyntheticsRunTests@0
+- task: SyntheticsRunTests@1
   displayName: Run Datadog Synthetic tests
   inputs:
     authenticationType: 'connectedService'
@@ -57,7 +61,7 @@ Your task can be [simple](#simple-usage) or [complex](#complex-usage).
 ### Example task using existing `synthetics.json` files
 
 ```yaml
-- task: SyntheticsRunTests@0
+- task: SyntheticsRunTests@1
   displayName: Run Datadog Synthetic tests
   inputs:
     authenticationType: 'connectedService'
@@ -70,7 +74,7 @@ For an example test file, see this [`test.synthetics.json` file][14].
 ### Example task using pipeline secrets for authentication
 
 ```yaml
-- task: SyntheticsRunTests@0
+- task: SyntheticsRunTests@1
   inputs:
     authenticationType: 'apiAppKeys'
     apiKey: '$(DatadogApiKey)'
@@ -81,10 +85,14 @@ For an example test file, see this [`test.synthetics.json` file][14].
 
 ## Complex usage
 
+> **Note**: We recently changed the major version of the task from `SyntheticsRunTests@0` to `SyntheticsRunTests@1`.
+>
+> This is **NOT a breaking change**, but an alignment between the task version and the extension version.
+
 ### Example task using the `testSearchQuery`
 
 ```yaml
-- task: SyntheticsRunTests@0
+- task: SyntheticsRunTests@1
   displayName: Run Datadog Synthetic tests
   inputs:
     authenticationType: 'connectedService'
@@ -98,7 +106,7 @@ For an example test file, see this [`test.synthetics.json` file][14].
 ### Example task using the `testSearchQuery` and variable overrides
 
 ```yaml
-- task: SyntheticsRunTests@0
+- task: SyntheticsRunTests@1
   displayName: Run Datadog Synthetic tests
   inputs:
     authenticationType: 'connectedService'
@@ -111,7 +119,7 @@ For an example test file, see this [`test.synthetics.json` file][14].
 This task overrides the path to the global `datadog-ci.config.json` file.
 
 ```yaml
-- task: SyntheticsRunTests@0
+- task: SyntheticsRunTests@1
   displayName: Run Datadog Synthetic tests
   inputs:
     authenticationType: 'connectedService'

--- a/SyntheticsRunTestsTask/__tests__/main.test.ts
+++ b/SyntheticsRunTestsTask/__tests__/main.test.ts
@@ -33,7 +33,7 @@ describe('Test suite', () => {
     })
 
     expect(task.succeeded).toBe(true)
-    expect(task.warningIssues).toStrictEqual([expect.stringContaining('The `SyntheticsRunTests@0` task is deprecated')])
+    expect(task.warningIssues.length).toEqual(0)
     expect(task.errorIssues.length).toEqual(0)
   })
 
@@ -41,7 +41,7 @@ describe('Test suite', () => {
     const task = runMockTaskServiceConnectionMisconfigured()
 
     expect(task.succeeded).toBe(false)
-    expect(task.warningIssues).toStrictEqual([expect.stringContaining('The `SyntheticsRunTests@0` task is deprecated')])
+    expect(task.warningIssues.length).toEqual(0)
     expect(task.errorIssues.length).toEqual(2)
     expect(task.errorIssues[0]).toEqual(
       'Missing API or APP keys to initialize datadog-ci! Check your Datadog service connection.'
@@ -71,7 +71,7 @@ describe('Test suite', () => {
     })
 
     expect(task.succeeded).toBe(true)
-    expect(task.warningIssues).toStrictEqual([expect.stringContaining('The `SyntheticsRunTests@0` task is deprecated')])
+    expect(task.warningIssues.length).toEqual(0)
     expect(task.errorIssues.length).toEqual(0)
   })
 
@@ -91,7 +91,7 @@ describe('Test suite', () => {
     })
 
     expect(task.succeeded).toBe(true)
-    expect(task.warningIssues).toStrictEqual([expect.stringContaining('The `SyntheticsRunTests@0` task is deprecated')])
+    expect(task.warningIssues.length).toEqual(0)
     expect(task.errorIssues.length).toEqual(0)
   })
 
@@ -109,7 +109,7 @@ describe('Test suite', () => {
     })
 
     expect(task.succeeded).toBe(true)
-    expect(task.warningIssues).toStrictEqual([expect.stringContaining('The `SyntheticsRunTests@0` task is deprecated')])
+    expect(task.warningIssues.length).toEqual(0)
     expect(task.errorIssues.length).toEqual(0)
 
     expect(fs.existsSync('./reports/TEST-1.xml')).toBe(true)
@@ -134,7 +134,7 @@ describe('Test suite', () => {
     })
 
     expect(task.succeeded).toBe(true)
-    expect(task.warningIssues).toStrictEqual([expect.stringContaining('The `SyntheticsRunTests@0` task is deprecated')])
+    expect(task.warningIssues.length).toEqual(0)
     expect(task.errorIssues.length).toEqual(0)
   })
 })

--- a/SyntheticsRunTestsTask/task.json
+++ b/SyntheticsRunTestsTask/task.json
@@ -7,9 +7,9 @@
   "releaseNotes": "Run Datadog Synthetics CI tests as part of your Azure pipelines",
   "category": "Test",
   "version": {
-    "Major": 0,
-    "Minor": 1,
-    "Patch": 5
+    "Major": 1,
+    "Minor": 5,
+    "Patch": 0
   },
   "preview": true,
   "instanceNameFormat": "Run Datadog Synthetics CI tests",

--- a/SyntheticsRunTestsTask/task.ts
+++ b/SyntheticsRunTestsTask/task.ts
@@ -4,17 +4,10 @@ import * as task from 'azure-pipelines-task-lib/task'
 
 import {getReporter, resolveConfig} from './resolve-config'
 import {synthetics} from '@datadog/datadog-ci'
-import {LogType, logError} from 'azure-pipelines-tasks-packaging-common/util'
 
 async function run(): Promise<void> {
   task.setResourcePath(path.join(__dirname, 'task.json'))
   synthetics.utils.setCiTriggerApp('azure_devops_task')
-
-  logError(
-    'The `SyntheticsRunTests@0` task is deprecated, please use `SyntheticsRunTests@1` instead.\n' +
-      'This is NOT a breaking change, but an alignment between the task version and the extension version.',
-    LogType.warning
-  )
 
   const reporter = getReporter()
   const config = await resolveConfig(reporter)

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "datadog-ci",
   "publisher": "Datadog",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "name": "Datadog Continuous Testing",
   "description": "Use Browser and API tests in your Azure pipelines with Datadog Continuous Testing",
   "public": false,


### PR DESCRIPTION
**Recent updates:**
- The extension was renamed from `Datadog CI` to `Datadog Continuous Testing` (released in [`v1.4.1`](https://github.com/DataDog/datadog-ci-azure-devops/releases/tag/v1.4.1)).
- As of `v1.5.0`, the task will have to be referred to with `SyntheticsRunTests@1`
  - Otherwise, `SyntheticsRunTests@0` will fall back to the last task that we published under this major version, i.e. `SyntheticsRunTests@0.1.5` (contributed in extension `v1.4.1`). And it will show a deprecation notice.

This PR [updates the README](https://github.com/DataDog/datadog-ci-azure-devops/blob/corentin.girard/release-1-5-0/README.md) to show a note saying that we recently went from `SyntheticsRunTests@0` to `SyntheticsRunTests@1`.