### PR TITLE
[ci] Fix release public extension stage ID

### DIFF
--- a/.azure-pipelines/main-pipeline.yml
+++ b/.azure-pipelines/main-pipeline.yml
@@ -137,8 +137,8 @@ stages:
 
   # Extension public release, only performed on manual runs
   - ${{ if eq(parameters.performRelease, true) }}:
-      - stage: Release public extension
-        dependsOn: Build
+      - stage: ReleasePublic
+        displayName: Release public extension
         jobs:
           - job: PublishPublic
             displayName: Publish (public)


### PR DESCRIPTION
Because of #64 ([this change exactly](https://github.com/DataDog/datadog-ci-azure-devops/pull/64/files#diff-c6936e65a91f58c27c66f2f1285fb4cfcc3f2fb638805febfb7223bc4e979efeR140)), the "Release public extension" stage now fails to be started (see screenshot below).

This PR fixes this issue, in order to release `v1.4.1` (#76).

![image](https://github.com/DataDog/datadog-ci-azure-devops/assets/9317502/04d210cb-2854-489d-8da0-03b82bbd0180)