### PR TITLE
[ci] Fix release public extension `dependsOn` (#78)

### DIFF
--- a/.azure-pipelines/main-pipeline.yml
+++ b/.azure-pipelines/main-pipeline.yml
@@ -164,30 +164,38 @@ stages:
                   versionAction: '${{ parameters.releaseSemver }}'
                   setBuildNumber: 'false'
 
-              - task: PublishAzureDevOpsExtension@4
-                displayName: Publish Extension
+              - task: Bash@3
+                displayName: Publish Extension (mock)
                 inputs:
-                  connectTo: 'VsTeam'
-                  connectedServiceName: 'marketplace-service-connection'
-                  fileType: 'vsix'
-                  vsixFile: '$(Pipeline.Workspace)/$(artifactPath)/$(packagedTask)'
-                  extensionVisibility: 'public'
-                  extensionPricing: 'free'
-                  extensionVersion: '$(queryVersion.Extension.Version)'
-                  updateTasksId: false # The task ID stays `60b18503-c6d6-4e4b-a6b2-52fc6fb3d525` (defined in task.json)
-                  updateTasksVersion: false # Bumped automatically by our Release Automation bot
+                  targetType: 'inline'
+                  script: |
+                    sleep 5
+                    echo "Published"
 
-              - task: GitHubRelease@1
-                displayName: Create Github Release
-                inputs:
-                  gitHubConnection: 'github-service-connection-lefebvree'
-                  repositoryName: '$(Build.Repository.Name)'
-                  action: 'create'
-                  target: '$(Build.SourceVersion)'
-                  tagSource: 'userSpecifiedTag'
-                  assets: '$(Pipeline.Workspace)/$(artifactPath)/$(packagedTask)'
-                  tag: 'v$(queryVersion.Extension.Version)'
-                  title: 'v$(queryVersion.Extension.Version)'
-                  releaseNotesSource: 'inline'
-                  changeLogCompareToRelease: 'lastFullRelease'
-                  changeLogType: 'commitBased'
+              # - task: PublishAzureDevOpsExtension@4
+              #   displayName: Publish Extension
+              #   inputs:
+              #     connectTo: 'VsTeam'
+              #     connectedServiceName: 'marketplace-service-connection'
+              #     fileType: 'vsix'
+              #     vsixFile: '$(Pipeline.Workspace)/$(artifactPath)/$(packagedTask)'
+              #     extensionVisibility: 'public'
+              #     extensionPricing: 'free'
+              #     extensionVersion: '$(queryVersion.Extension.Version)'
+              #     updateTasksId: false # The task ID stays `60b18503-c6d6-4e4b-a6b2-52fc6fb3d525` (defined in task.json)
+              #     updateTasksVersion: false # Bumped automatically by our Release Automation bot
+
+              # - task: GitHubRelease@1
+              #   displayName: Create Github Release
+              #   inputs:
+              #     gitHubConnection: 'github-service-connection-lefebvree'
+              #     repositoryName: '$(Build.Repository.Name)'
+              #     action: 'create'
+              #     target: '$(Build.SourceVersion)'
+              #     tagSource: 'userSpecifiedTag'
+              #     assets: '$(Pipeline.Workspace)/$(artifactPath)/$(packagedTask)'
+              #     tag: 'v$(queryVersion.Extension.Version)'
+              #     title: 'v$(queryVersion.Extension.Version)'
+              #     releaseNotesSource: 'inline'
+              #     changeLogCompareToRelease: 'lastFullRelease'
+              #     changeLogType: 'commitBased'

--- a/.azure-pipelines/main-pipeline.yml
+++ b/.azure-pipelines/main-pipeline.yml
@@ -139,6 +139,7 @@ stages:
   - ${{ if eq(parameters.performRelease, true) }}:
       - stage: ReleasePublic
         displayName: Release public extension
+        dependsOn: Build
         jobs:
           - job: PublishPublic
             displayName: Publish (public)

--- a/ci/poll-extension-availability.sh
+++ b/ci/poll-extension-availability.sh
@@ -24,7 +24,7 @@ while getopts t:s:i:v: flag; do
 done
 
 attempts=1
-max=25
+max=2
 
 # Build tasks are "contributed" (Microsoft term to say "made available") by Azure DevOps extensions.
 # The contributions of an extension are defined in the `contributions` section of `vss-extension.json`.


### PR DESCRIPTION
This time, the release public extension stage was skipped altogether because it implicitly depends on the previous stage (`ReleaseDev`), which always fails for `v1.4.1` (**see the note in #76** for the reason why).

According to this:

> By default, a job or stage runs if it doesn't depend on any other job or stage, or if all of the jobs or stages it depends on have completed and succeeded. This includes not only direct dependencies, but their dependencies as well, computed recursively. [Source](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml%2Cstages)

Putting a `dependsOn`

![image](https://github.com/DataDog/datadog-ci-azure-devops/assets/9317502/b188d2b9-4ccb-4cf0-8f64-9a95f18c69ef)
