### PR TITLE
[ci] Run dev pipeline on main branch

### DIFF
--- a/.azure-pipelines/dev-pipeline.yml
+++ b/.azure-pipelines/dev-pipeline.yml
@@ -1,6 +1,8 @@
-trigger: none # Disable individual commit runs. https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#opting-out-of-ci
+# Run on commits, only on `main`.
+trigger:
+  - main
 
-# The pipeline requires a PR to run on branches.
+# Require a PR to run on branches.
 pr:
   branches:
     include:

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -1,6 +1,6 @@
 pr: none # Disable PR runs. https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#pr-triggers
 
-# Pipeline requires a version tag to run.
+# Requires a version tag to run.
 trigger:
   branches:
     include:


### PR DESCRIPTION
After #73, we lost the DEV pipeline on the `main` branch. It's not ideal since it triggers the E2E tests, meaning that the `main` branch is not end-to-end tested anymore.

<img width="838" alt="image" src="https://github.com/DataDog/datadog-ci-azure-devops/assets/9317502/398bf7b6-b526-4e17-8ca3-01417024bced">
