### PR TITLE
[dep] Bump follow-redirects to `1.15.6`

### DIFF
--- a/SyntheticsRunTestsTask/yarn.lock
+++ b/SyntheticsRunTestsTask/yarn.lock
@@ -4584,17 +4584,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.1":
-  version: 1.15.5
-  resolution: "follow-redirects@npm:1.15.5"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: 5ca49b5ce6f44338cbfc3546823357e7a70813cecc9b7b768158a1d32c1e62e7407c944402a918ea8c38ae2e78266312d617dc68783fac502cbb55e1047b34ec
-  languageName: node
-  linkType: hard
-
-"follow-redirects@npm:^1.15.6":
+"follow-redirects@npm:^1.15.1, follow-redirects@npm:^1.15.6":
   version: 1.15.6
   resolution: "follow-redirects@npm:1.15.6"
   peerDependenciesMeta:


### PR DESCRIPTION
Fix https://github.com/DataDog/datadog-ci-azure-devops/security/dependabot/28