### PR TITLE
Remove usage of deprecated `global`

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ For an example test file, see this [`test.synthetics.json` file][14].
       PASSWORD=$(StagingPassword)
 ```
 
-### Example task using a global configuration override with `configPath`
+### Example task using a global configuration file with `configPath`
 
-This task overrides the path to the global `datadog-ci.config.json` file.
+By default, the path to the global configuration file is `datadog-ci.json`. You can override this path with the `config_path` input.
 
 ```yaml
 - task: SyntheticsRunTests@1
@@ -124,10 +124,10 @@ This task overrides the path to the global `datadog-ci.config.json` file.
   inputs:
     authenticationType: 'connectedService'
     connectedService: 'my-datadog-ci-connected-service'
-    configPath: './synthetics-config.json'
+    configPath: './global.config.json'
 ```
 
-For an example configuration file, see this [`global.config.json` file][13].
+For an example of global configuration file, see this [`global.config.json` file][13].
 
 ## Inputs
 
@@ -142,7 +142,7 @@ For an example configuration file, see this [`global.config.json` file][13].
 | `publicIds`            | _optional_  | A list of tests IDs for Synthetic tests you want to trigger, separated by new lines or commas. If no value is provided, the task looks for files named `synthetics.json`.                                                                       |
 | `testSearchQuery`      | _optional_  | Trigger tests corresponding to a [search][8] query. This can be useful if you are tagging your test configurations. For more information, see [rules and best practices for naming tags][10].                                                   |
 | `files`                | _optional_  | Glob pattern to detect Synthetic tests' config files. **Default:** `{,!(node_modules)/**/}*.synthetics.json`.                                                                                                                                   |
-| `configPath`           | _optional_  | The global JSON configuration used when launching tests. For more information, see the [example configuration][9]. **Default:** `datadog-ci.json`.                                                                                              |
+| `configPath`           | _optional_  | The [global JSON configuration][9] used when launching tests. For more information, see the [example configuration][9]. **Default:** `datadog-ci.json`.                                                                                         |
 | `variables`            | _optional_  | A list of global variables to use for Synthetic tests, separated by new lines or commas. For example: `START_URL=https://example.org,MY_VARIABLE=My title`. **Default:** `[]`.                                                                  |
 | `jUnitReport`          | _optional_  | The filename for a JUnit report if you want to generate one.                                                                                                                                                                                    |
 | `pollingTimeout`       | _optional_  | The duration (in milliseconds) after which the task stops polling for test results. At the CI level, test results completed after this duration are considered failed. **Default:** 30 minutes.                                                 |

--- a/SyntheticsRunTestsTask/__tests__/main.test.ts
+++ b/SyntheticsRunTestsTask/__tests__/main.test.ts
@@ -25,8 +25,8 @@ describe('Test suite', () => {
     expectSpy(task, synthetics.executeTests).toHaveBeenCalledWith(expect.anything(), {
       ...BASE_CONFIG,
       ...BASE_INPUTS,
-      global: {
-        ...BASE_CONFIG.global,
+      defaultTestOverrides: {
+        ...BASE_CONFIG.defaultTestOverrides,
         pollingTimeout: BASE_CONFIG.pollingTimeout,
       },
       publicIds: CUSTOM_PUBLIC_IDS,
@@ -61,8 +61,8 @@ describe('Test suite', () => {
       publicIds: CUSTOM_PUBLIC_IDS,
       datadogSite: CUSTOM_SITE,
       subdomain: CUSTOM_SUBDOMAIN,
-      global: {
-        ...BASE_CONFIG.global,
+      defaultTestOverrides: {
+        ...BASE_CONFIG.defaultTestOverrides,
         pollingTimeout: BASE_CONFIG.pollingTimeout,
         variables: {
           FOO: 'bar',
@@ -81,8 +81,8 @@ describe('Test suite', () => {
     expectSpy(task, synthetics.executeTests).toHaveBeenCalledWith(expect.anything(), {
       ...BASE_CONFIG,
       ...BASE_INPUTS,
-      global: {
-        ...BASE_CONFIG.global,
+      defaultTestOverrides: {
+        ...BASE_CONFIG.defaultTestOverrides,
         pollingTimeout: BASE_CONFIG.pollingTimeout,
       },
       datadogSite: CUSTOM_SITE,
@@ -101,8 +101,8 @@ describe('Test suite', () => {
     expectSpy(task, synthetics.executeTests).toHaveBeenCalledWith(expect.anything(), {
       ...BASE_CONFIG,
       ...BASE_INPUTS,
-      global: {
-        ...BASE_CONFIG.global,
+      defaultTestOverrides: {
+        ...BASE_CONFIG.defaultTestOverrides,
         pollingTimeout: BASE_CONFIG.pollingTimeout,
       },
       publicIds: CUSTOM_PUBLIC_IDS,
@@ -125,8 +125,8 @@ describe('Test suite', () => {
     expectSpy(task, synthetics.executeTests).toHaveBeenCalledWith(expect.anything(), {
       ...BASE_CONFIG,
       ...BASE_INPUTS,
-      global: {
-        ...BASE_CONFIG.global,
+      defaultTestOverrides: {
+        ...BASE_CONFIG.defaultTestOverrides,
         pollingTimeout: 3600000,
       },
       pollingTimeout: 3600000,

--- a/SyntheticsRunTestsTask/resolve-config.ts
+++ b/SyntheticsRunTestsTask/resolve-config.ts
@@ -113,8 +113,8 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
       publicIds,
       subdomain,
       testSearchQuery,
-      global: deepExtend(
-        config.global,
+      defaultTestOverrides: deepExtend(
+        config.defaultTestOverrides,
         utils.removeUndefinedValues({
           pollingTimeout,
           variables: synthetics.utils.parseVariablesFromCli(variableStrings, reporter.log.bind(reporter)),
@@ -123,8 +123,8 @@ export const resolveConfig = async (reporter: synthetics.MainReporter): Promise<
     })
   )
 
-  // Pass root polling timeout to global override to get it applied to all tests if not defined individually
-  config.global.pollingTimeout = config.global.pollingTimeout ?? config.pollingTimeout
+  // Pass root polling timeout to default test overrides to get it applied to all tests if not defined individually
+  config.defaultTestOverrides.pollingTimeout = config.defaultTestOverrides.pollingTimeout ?? config.pollingTimeout
 
   return config
 }

--- a/SyntheticsRunTestsTask/task.json
+++ b/SyntheticsRunTestsTask/task.json
@@ -94,7 +94,7 @@
       "type": "filePath",
       "label": "Global JSON configuration",
       "defaultValue": "",
-      "helpMarkDown": "The global JSON configuration is used when launching tests. See the [example configuration](https://docs.datadoghq.com/synthetics/cicd_integrations/configuration/?tabs=npm#setup-a-client) for more details."
+      "helpMarkDown": "The [global JSON configuration](https://docs.datadoghq.com/continuous_testing/cicd_integrations/configuration/?tab=npm#setup-the-client) is used when launching tests. See the [example configuration](https://docs.datadoghq.com/synthetics/cicd_integrations/configuration/?tabs=npm#setup-a-client) for more details."
     },
     {
       "name": "variables",

--- a/ci/e2e.config.json
+++ b/ci/e2e.config.json
@@ -1,5 +1,5 @@
 {
-  "global": {
+  "defaultTestOverrides": {
     "headers": {
       "X-Fake-Header": "fake value"
     },


### PR DESCRIPTION
See https://github.com/DataDog/datadog-ci/pull/1285