### PR TITLE
[ci] Update release instructions

### DIFF
--- a/.github/workflows/bump-datadog-ci.yml
+++ b/.github/workflows/bump-datadog-ci.yml
@@ -88,6 +88,8 @@ jobs:
             const body = `This PR was automatically created because a new version of datadog-ci was published.
 
             > [!IMPORTANT]
+            > **Important:** Please comment \`/azp run\` on the PR to run the Azure pipelines.
+            > 
             > **You are not done!**
             > 
             > Once this PR is merged, please run the ["Create Release PR" workflow](../actions/workflows/release-version.yml).

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -92,7 +92,9 @@ jobs:
             The description of the release will exactly match this PR's description. Feel free to edit it.
 
             > [!WARNING]
-            > The \`Release\` pipeline (which publishes the **public** extension) won't be triggered because the creator of the tag is the [Release Automation](https://github.com/apps/ci-integrations-release-automation) github app, which is seen as a bot by Azure DevOps.
+            > **Important:** Please comment \`/azp run\` on the PR to run the Azure pipelines.
+            >
+            > When the PR is merged, the \`Release\` pipeline (which publishes the **public** extension) won't be triggered because the creator of the tag is the [Release Automation](https://github.com/apps/ci-integrations-release-automation) github app, which is seen as a bot by Azure DevOps.
             >
             > To trigger it manually, please \`Run the pipeline\` [here](https://datadog-ci.visualstudio.com/Datadog%20CI%20Azure%20DevOps%20Extension/_build?definitionId=8) on Azure DevOps.
             > You should change the \`Branch/tag\` to \`refs/tags/${{ steps.bump-version.outputs.NEW_VERSION_TAG }}\`.`


### PR DESCRIPTION
Added the following line to the release instructions:

> **Important:** Please comment `/azp run` on the PR to run the Azure pipelines.