### PR TITLE
ci(workflows): use official GitHub action for token generation

### DIFF
--- a/.github/workflows/bump-datadog-ci.yml
+++ b/.github/workflows/bump-datadog-ci.yml
@@ -26,10 +26,10 @@ jobs:
       # Do the changes
       - name: Get GitHub App token
         id: get-token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
-          private_key: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
+          private-key: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -89,9 +89,9 @@ jobs:
 
             > [!IMPORTANT]
             > **Important:** Please comment \`/azp run\` on the PR to run the Azure pipelines.
-            > 
+            >
             > **You are not done!**
-            > 
+            >
             > Once this PR is merged, please run the ["Create Release PR" workflow](../actions/workflows/release-version.yml).
             > This time, it will create a **release PR** for you, which will publish the CI integration once merged.`
 

--- a/.github/workflows/release-version-on-merge.yml
+++ b/.github/workflows/release-version-on-merge.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get-token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
-          private_key: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
+          private-key: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
       - name: Create GitHub release
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -25,10 +25,10 @@ jobs:
       # Do the changes
       - name: Get GitHub App token
         id: get-token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
-          private_key: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
+          private-key: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Changes
- Changes use of action `tibdex/github-app-token` to official GitHub one