### PR TITLE
[SYNTH-19621] Expose variables to other tasks

### DIFF
--- a/.azure-pipelines/e2e-pipeline.yml
+++ b/.azure-pipelines/e2e-pipeline.yml
@@ -29,12 +29,47 @@ stages:
         steps:
           - task: Datadog.datadog-ci-dev.synthetics-application-testing.SyntheticsRunTests@2
             displayName: Run DEV task - apiAppKeys
+            name: runSyntheticsTests
             inputs:
               authenticationType: 'apiAppKeys'
               apiKey: '$(API_KEY)'
               appKey: '$(APP_KEY)'
               publicIds: '2r9-q7u-4nn,pwd-mwg-3p5'
               configPath: 'ci/e2e.config.json'
+
+          # Example of using outputs
+          - script: |
+              echo 'Batch URL: $(runSyntheticsTests.batchUrl)'
+              echo 'Raw Results:'
+              echo '$(runSyntheticsTests.rawResults)' | jq '.'
+            displayName: Example of using outputs
+
+          # Example of parsing and using raw results with JS
+          - task: NodeTool@0
+            displayName: 'Install Node.js'
+            inputs:
+              versionSpec: '20.x'
+          # Linux only
+          - bash: |
+              cat > parse-results.js << 'EOF'
+                const rawResults = JSON.parse(process.env.RAW_RESULTS);
+                console.log('Parsed Raw Results:', rawResults);
+              EOF
+            displayName: Prepare script (Linux)
+            condition: eq(variables['Agent.OS'], 'Linux')
+          # Windows only
+          - powershell: |
+              @'
+                const rawResults = JSON.parse(process.env.RAW_RESULTS);
+                console.log('Parsed Raw Results:', rawResults);
+              '@ | Out-File -FilePath parse-results.js -Encoding utf8
+            displayName: Prepare script (Windows)
+            condition: eq(variables['Agent.OS'], 'Windows_NT')
+          # Run the script
+          - script: node parse-results.js
+            displayName: Example of parsing and using raw results with JS
+            env:
+              RAW_RESULTS: $(runSyntheticsTests.rawResults)
 
           - task: Datadog.datadog-ci-dev.synthetics-application-testing.SyntheticsRunTests@2
             displayName: Run DEV task - connectedService

--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ For an example of a global configuration file, see this [`global.config.json` fi
 | `testSearchQuery`      | _optional_  | Trigger tests corresponding to a [search][8] query. This can be useful if you are tagging your test configurations. For more information, see [rules and best practices for naming tags][10].                                                   |
 | `variables`            | _optional_  | Key-value pairs for injecting variables into tests, separated by newlines or commas. For example: `START_URL=https://example.org,MY_VARIABLE=My title`. **Default:** `[]`.                                                                      |
 
+## Outputs
+
+| Name                     | Type   | Description                                |
+| ------------------------ | ------ | ------------------------------------------ |
+| `batchUrl`               | string | The URL of the batch.                      |
+| `criticalErrorsCount`    | number | The number of critical errors.             |
+| `failedCount`            | number | The number of failed results.              |
+| `failedNonBlockingCount` | number | The number of failed non-blocking results. |
+| `passedCount`            | number | The number of passed results.              |
+| `previouslyPassedCount`  | number | The number of previously passed results.   |
+| `testsNotFoundCount`     | number | The number of not found tests.             |
+| `testsSkippedCount`      | number | The number of skipped tests.               |
+| `timedOutCount`          | number | The number of timed out results.           |
+| `rawResults`             | string | The list of results, as a raw JSON string. |
+
 ## Further reading
 
 Additional helpful documentation, links, and articles:

--- a/SyntheticsRunTestsTask/__tests__/main.test.ts
+++ b/SyntheticsRunTestsTask/__tests__/main.test.ts
@@ -7,7 +7,7 @@ import {BASE_INPUTS, CUSTOM_PUBLIC_IDS, CUSTOM_SITE, CUSTOM_SUBDOMAIN, expectSpy
 const BASE_CONFIG = synthetics.DEFAULT_COMMAND_CONFIG
 
 describe('Test suite', () => {
-  test('succeeds when app and api keys are given', async () => {
+  test('succeeds when api and app keys are given', async () => {
     const result = await runScenario('api-keys')
 
     expectSpy(result, synthetics.executeTests).toHaveBeenCalledWith(expect.anything(), {
@@ -19,6 +19,27 @@ describe('Test suite', () => {
     expect(result.succeeded).toBe(true)
     expect(result.warningIssues.length).toEqual(0)
     expect(result.errorIssues.length).toEqual(0)
+
+    const output = result.stdout.split('\n').filter(line => line.includes('##vso[task.setvariable'))
+
+    const setVariableStr = (name: string, value: string): string =>
+      `##vso[task.setvariable variable=${name};isOutput=true;issecret=false;]${value}`
+
+    expect(output.length).toEqual(10)
+    expect(output[0]).toContain(
+      setVariableStr('batchUrl', 'https://app.datadoghq.com/synthetics/explorer/ci?batchResultId=batch-id')
+    )
+    expect(output[1]).toContain(setVariableStr('criticalErrorsCount', '1'))
+    expect(output[2]).toContain(setVariableStr('failedNonBlockingCount', '3'))
+    expect(output[3]).toContain(setVariableStr('failedCount', '2'))
+    expect(output[4]).toContain(setVariableStr('passedCount', '4'))
+    expect(output[5]).toContain(setVariableStr('previouslyPassedCount', '5'))
+    expect(output[6]).toContain(setVariableStr('testsNotFoundCount', '1'))
+    expect(output[7]).toContain(setVariableStr('testsSkippedCount', '6'))
+    expect(output[8]).toContain(setVariableStr('timedOutCount', '7'))
+    expect(output[9]).toContain(
+      setVariableStr('rawResults', JSON.stringify([{passed: true, result: {startUrl: 'https://example.org'}}]))
+    )
   })
 
   test('fails when service connection has empty app or api keys', async () => {

--- a/SyntheticsRunTestsTask/__tests__/scenarios/api-keys.ts
+++ b/SyntheticsRunTestsTask/__tests__/scenarios/api-keys.ts
@@ -2,11 +2,31 @@ import {join} from 'path'
 
 import {TaskMockRunner} from 'azure-pipelines-task-lib/mock-run'
 
-import {BASE_INPUTS, CUSTOM_PUBLIC_IDS, setupMocks} from '../fixtures'
+import {BASE_INPUTS, CUSTOM_PUBLIC_IDS, EMPTY_SUMMARY, setupMocks} from '../fixtures'
+import {synthetics} from '@datadog/datadog-ci'
 
 const mockRunner = new TaskMockRunner(join(__dirname, '../..', 'task.js'))
 
-setupMocks(mockRunner)
+setupMocks(mockRunner, {
+  executeTestsResult: {
+    results: [
+      {passed: true, result: {startUrl: 'https://example.org'} as synthetics.ServerResult} as synthetics.Result,
+    ],
+    summary: {
+      ...EMPTY_SUMMARY,
+      batchId: 'batch-id',
+      criticalErrors: 1,
+      failed: 2,
+      failedNonBlocking: 3,
+      passed: 4,
+      previouslyPassed: 5,
+      skipped: 6,
+      testsNotFound: new Set(['test-not-found']),
+      timedOut: 7,
+    },
+  },
+  noOpRenderResults: true,
+})
 
 mockRunner.setInput('authenticationType', 'apiAppKeys')
 mockRunner.setInput('apiKey', BASE_INPUTS.apiKey)


### PR DESCRIPTION
- https://github.com/DataDog/datadog-ci-azure-devops/pull/217
- https://github.com/DataDog/datadog-ci-azure-devops/pull/215 (← **you are here**)

Like https://github.com/DataDog/synthetics-ci-github-action/pull/309, we want to expose outputs to other Azure DevOps tasks too.