### PR TITLE
[chores] Speed up unit tests by mocking `getOrgSettings`

### DIFF
--- a/.azure-pipelines/dev-pipeline.yml
+++ b/.azure-pipelines/dev-pipeline.yml
@@ -45,7 +45,7 @@ stages:
           - task: NodeTool@0
             displayName: Install Node.js
             inputs:
-              versionSpec: '16.15.0'
+              versionSpec: '20.11.0'
 
           - task: Bash@3
             displayName: Compile the Synthetics task

--- a/.azure-pipelines/e2e-pipeline.yml
+++ b/.azure-pipelines/e2e-pipeline.yml
@@ -27,7 +27,7 @@ stages:
         pool:
           vmImage: $(imageName)
         steps:
-          - task: Datadog.datadog-ci-dev.synthetics-application-testing.SyntheticsRunTests@1
+          - task: Datadog.datadog-ci-dev.synthetics-application-testing.SyntheticsRunTests@2
             displayName: Run DEV task - apiAppKeys
             inputs:
               authenticationType: 'apiAppKeys'
@@ -36,7 +36,7 @@ stages:
               publicIds: '2r9-q7u-4nn,pwd-mwg-3p5'
               configPath: 'ci/e2e.config.json'
 
-          - task: Datadog.datadog-ci-dev.synthetics-application-testing.SyntheticsRunTests@1
+          - task: Datadog.datadog-ci-dev.synthetics-application-testing.SyntheticsRunTests@2
             displayName: Run DEV task - connectedService
             inputs:
               authenticationType: 'connectedService'

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -40,7 +40,7 @@ stages:
           - task: NodeTool@0
             displayName: Install Node.js
             inputs:
-              versionSpec: '16.15.0'
+              versionSpec: '20.11.0'
 
           - task: Bash@3
             displayName: Compile the Synthetics task

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,7 +5,7 @@ name: Run unit tests
 on: push
 
 jobs:
-  build-and-test-synthetics:
+  build-and-test:
     name: Build and test SyntheticsRunTestsTask
     runs-on: ubuntu-latest
 
@@ -23,4 +23,4 @@ jobs:
       - run: yarn lint
       - run: yarn build && yarn test
         env:
-          FORCE_COLOR: '1'
+          FORCE_COLOR: 1

--- a/SyntheticsRunTestsTask/__tests__/fixtures.ts
+++ b/SyntheticsRunTestsTask/__tests__/fixtures.ts
@@ -1,10 +1,11 @@
 import chalk from 'chalk'
 import {relative, join} from 'path'
+import {synthetics, utils} from '@datadog/datadog-ci'
 
-import {synthetics} from '@datadog/datadog-ci'
 import {MockTestRunner} from 'azure-pipelines-task-lib/mock-test'
 
 import * as fs from 'fs'
+import {TaskMockRunner} from 'azure-pipelines-task-lib/mock-run'
 
 export const BASE_INPUTS = {
   apiKey: 'xxx',
@@ -95,7 +96,7 @@ export const expectSpy = <Fn extends typeof synthetics.executeTests>(
   },
 })
 
-export const setupWarnSpy = (): void => {
+const setupWarnSpy = (): void => {
   // If we don't do this, warnings are not prefixed with `##vso[task` and excluded from `task.stdout`.
   console.warn = (...data) => {
     console.log('##vso[task.warn]', ...data)
@@ -103,4 +104,24 @@ export const setupWarnSpy = (): void => {
 
   // We can't do this for errors because it changes the behavior too much: `task.errorIssues` gets broken
   // AND we actually expect errors in some tests.
+}
+
+export const setupMocks = (mockRunner: TaskMockRunner): void => {
+  setupWarnSpy()
+
+  mockRunner.registerMock('@datadog/datadog-ci', {
+    utils,
+    synthetics: {
+      ...synthetics,
+      executeTests: async (
+        ...args: Parameters<typeof synthetics.executeTests>
+      ): ReturnType<typeof synthetics.executeTests> => {
+        spyLog(synthetics.executeTests, args)
+        return {
+          results: [],
+          summary: EMPTY_SUMMARY,
+        }
+      },
+    },
+  })
 }

--- a/SyntheticsRunTestsTask/__tests__/fixtures.ts
+++ b/SyntheticsRunTestsTask/__tests__/fixtures.ts
@@ -113,6 +113,10 @@ export const setupMocks = (mockRunner: TaskMockRunner): void => {
     utils,
     synthetics: {
       ...synthetics,
+      utils: {
+        ...synthetics.utils,
+        getOrgSettings: async () => {},
+      },
       executeTests: async (
         ...args: Parameters<typeof synthetics.executeTests>
       ): ReturnType<typeof synthetics.executeTests> => {

--- a/SyntheticsRunTestsTask/__tests__/scenarios/api-keys.ts
+++ b/SyntheticsRunTestsTask/__tests__/scenarios/api-keys.ts
@@ -1,33 +1,16 @@
 import {join} from 'path'
 
-import {synthetics, utils} from '@datadog/datadog-ci'
 import {TaskMockRunner} from 'azure-pipelines-task-lib/mock-run'
 
-import {BASE_INPUTS, CUSTOM_PUBLIC_IDS, EMPTY_SUMMARY, setupWarnSpy, spyLog} from '../fixtures'
-
-setupWarnSpy()
+import {BASE_INPUTS, CUSTOM_PUBLIC_IDS, setupMocks} from '../fixtures'
 
 const mockRunner = new TaskMockRunner(join(__dirname, '../..', 'task.js'))
+
+setupMocks(mockRunner)
 
 mockRunner.setInput('authenticationType', 'apiAppKeys')
 mockRunner.setInput('apiKey', BASE_INPUTS.apiKey)
 mockRunner.setInput('appKey', BASE_INPUTS.appKey)
 mockRunner.setInput('publicIds', CUSTOM_PUBLIC_IDS.join(', '))
-
-mockRunner.registerMock('@datadog/datadog-ci', {
-  utils,
-  synthetics: {
-    ...synthetics,
-    executeTests: async (
-      ...args: Parameters<typeof synthetics.executeTests>
-    ): ReturnType<typeof synthetics.executeTests> => {
-      spyLog(synthetics.executeTests, args)
-      return {
-        results: [],
-        summary: EMPTY_SUMMARY,
-      }
-    },
-  },
-})
 
 mockRunner.run()

--- a/SyntheticsRunTestsTask/__tests__/scenarios/junit-report.ts
+++ b/SyntheticsRunTestsTask/__tests__/scenarios/junit-report.ts
@@ -1,34 +1,17 @@
 import {join} from 'path'
 
-import {synthetics, utils} from '@datadog/datadog-ci'
 import {TaskMockRunner} from 'azure-pipelines-task-lib/mock-run'
 
-import {BASE_INPUTS, CUSTOM_PUBLIC_IDS, EMPTY_SUMMARY, setupWarnSpy, spyLog} from '../fixtures'
-
-setupWarnSpy()
+import {BASE_INPUTS, CUSTOM_PUBLIC_IDS, setupMocks} from '../fixtures'
 
 const mockRunner = new TaskMockRunner(join(__dirname, '../..', 'task.js'))
+
+setupMocks(mockRunner)
 
 mockRunner.setInput('authenticationType', 'apiAppKeys')
 mockRunner.setInput('apiKey', BASE_INPUTS.apiKey)
 mockRunner.setInput('appKey', BASE_INPUTS.appKey)
 mockRunner.setInput('publicIds', CUSTOM_PUBLIC_IDS.join(', '))
 mockRunner.setInput('jUnitReport', 'reports/TEST-1.xml')
-
-mockRunner.registerMock('@datadog/datadog-ci', {
-  utils,
-  synthetics: {
-    ...synthetics,
-    executeTests: async (
-      ...args: Parameters<typeof synthetics.executeTests>
-    ): ReturnType<typeof synthetics.executeTests> => {
-      spyLog(synthetics.executeTests, args)
-      return {
-        results: [],
-        summary: EMPTY_SUMMARY,
-      }
-    },
-  },
-})
 
 mockRunner.run()

--- a/SyntheticsRunTestsTask/__tests__/scenarios/polling-timeout.ts
+++ b/SyntheticsRunTestsTask/__tests__/scenarios/polling-timeout.ts
@@ -1,34 +1,17 @@
 import {join} from 'path'
 
-import {synthetics, utils} from '@datadog/datadog-ci'
 import {TaskMockRunner} from 'azure-pipelines-task-lib/mock-run'
 
-import {BASE_INPUTS, CUSTOM_PUBLIC_IDS, EMPTY_SUMMARY, setupWarnSpy, spyLog} from '../fixtures'
-
-setupWarnSpy()
+import {BASE_INPUTS, CUSTOM_PUBLIC_IDS, setupMocks} from '../fixtures'
 
 const mockRunner = new TaskMockRunner(join(__dirname, '../..', 'task.js'))
+
+setupMocks(mockRunner)
 
 mockRunner.setInput('authenticationType', 'apiAppKeys')
 mockRunner.setInput('apiKey', BASE_INPUTS.apiKey)
 mockRunner.setInput('appKey', BASE_INPUTS.appKey)
 mockRunner.setInput('publicIds', CUSTOM_PUBLIC_IDS.join(', '))
 mockRunner.setInput('pollingTimeout', `${60 * 60 * 1000}`)
-
-mockRunner.registerMock('@datadog/datadog-ci', {
-  utils,
-  synthetics: {
-    ...synthetics,
-    executeTests: async (
-      ...args: Parameters<typeof synthetics.executeTests>
-    ): ReturnType<typeof synthetics.executeTests> => {
-      spyLog(synthetics.executeTests, args)
-      return {
-        results: [],
-        summary: EMPTY_SUMMARY,
-      }
-    },
-  },
-})
 
 mockRunner.run()

--- a/SyntheticsRunTestsTask/__tests__/scenarios/service-connection-env-vars.ts
+++ b/SyntheticsRunTestsTask/__tests__/scenarios/service-connection-env-vars.ts
@@ -1,21 +1,12 @@
 import {join} from 'path'
 
-import {synthetics, utils} from '@datadog/datadog-ci'
 import {TaskMockRunner} from 'azure-pipelines-task-lib/mock-run'
 
-import {
-  BASE_INPUTS,
-  CUSTOM_PUBLIC_IDS,
-  CUSTOM_SITE,
-  CUSTOM_SUBDOMAIN,
-  EMPTY_SUMMARY,
-  setupWarnSpy,
-  spyLog,
-} from '../fixtures'
-
-setupWarnSpy()
+import {BASE_INPUTS, CUSTOM_PUBLIC_IDS, CUSTOM_SITE, CUSTOM_SUBDOMAIN, setupMocks} from '../fixtures'
 
 const mockRunner = new TaskMockRunner(join(__dirname, '../..', 'task.js'))
+
+setupMocks(mockRunner)
 
 const CONNECTED_SERVICE_NAME = 'foo'
 
@@ -27,21 +18,5 @@ process.env[`ENDPOINT_URL_${CONNECTED_SERVICE_NAME}`] = `https://app.${CUSTOM_SI
 process.env[`ENDPOINT_AUTH_PARAMETER_${CONNECTED_SERVICE_NAME.toLocaleUpperCase()}_APITOKEN`] = BASE_INPUTS.apiKey
 process.env[`ENDPOINT_AUTH_PARAMETER_${CONNECTED_SERVICE_NAME.toLocaleUpperCase()}_APPKEY`] = BASE_INPUTS.appKey
 process.env[`ENDPOINT_DATA_${CONNECTED_SERVICE_NAME}_SUBDOMAIN`] = CUSTOM_SUBDOMAIN
-
-mockRunner.registerMock('@datadog/datadog-ci', {
-  utils,
-  synthetics: {
-    ...synthetics,
-    executeTests: async (
-      ...args: Parameters<typeof synthetics.executeTests>
-    ): ReturnType<typeof synthetics.executeTests> => {
-      spyLog(synthetics.executeTests, args)
-      return {
-        results: [],
-        summary: EMPTY_SUMMARY,
-      }
-    },
-  },
-})
 
 mockRunner.run()

--- a/SyntheticsRunTestsTask/__tests__/scenarios/service-connection-misconfigured.ts
+++ b/SyntheticsRunTestsTask/__tests__/scenarios/service-connection-misconfigured.ts
@@ -2,11 +2,11 @@ import {join} from 'path'
 
 import {TaskMockRunner} from 'azure-pipelines-task-lib/mock-run'
 
-import {setupWarnSpy} from '../fixtures'
-
-setupWarnSpy()
+import {setupMocks} from '../fixtures'
 
 const mockRunner = new TaskMockRunner(join(__dirname, '../..', 'task.js'))
+
+setupMocks(mockRunner)
 
 mockRunner.setInput('authenticationType', 'connectedService')
 mockRunner.setInput('connectedService', 'my service connection')

--- a/SyntheticsRunTestsTask/__tests__/scenarios/service-connection.ts
+++ b/SyntheticsRunTestsTask/__tests__/scenarios/service-connection.ts
@@ -1,22 +1,13 @@
 import {join} from 'path'
 
-import {synthetics, utils} from '@datadog/datadog-ci'
 import {TaskMockRunner} from 'azure-pipelines-task-lib/mock-run'
 import type task from 'azure-pipelines-task-lib/task'
 
-import {
-  BASE_INPUTS,
-  CUSTOM_PUBLIC_IDS,
-  CUSTOM_SITE,
-  CUSTOM_SUBDOMAIN,
-  EMPTY_SUMMARY,
-  setupWarnSpy,
-  spyLog,
-} from '../fixtures'
-
-setupWarnSpy()
+import {BASE_INPUTS, CUSTOM_PUBLIC_IDS, CUSTOM_SITE, CUSTOM_SUBDOMAIN, setupMocks} from '../fixtures'
 
 const mockRunner = new TaskMockRunner(join(__dirname, '../..', 'task.js'))
+
+setupMocks(mockRunner)
 
 mockRunner.setInput('authenticationType', 'connectedService')
 mockRunner.setInput('connectedService', 'my service connection')
@@ -42,21 +33,5 @@ taskMock.getEndpointAuthorizationParameterRequired = (_id: string, key: string) 
   }
 }
 mockRunner.registerMock('azure-pipelines-task-lib/mock-task', taskMock)
-
-mockRunner.registerMock('@datadog/datadog-ci', {
-  utils,
-  synthetics: {
-    ...synthetics,
-    executeTests: async (
-      ...args: Parameters<typeof synthetics.executeTests>
-    ): ReturnType<typeof synthetics.executeTests> => {
-      spyLog(synthetics.executeTests, args)
-      return {
-        results: [],
-        summary: EMPTY_SUMMARY,
-      }
-    },
-  },
-})
 
 mockRunner.run()

--- a/ci/increment-version.sh
+++ b/ci/increment-version.sh
@@ -28,4 +28,9 @@ sed -i -E "s/(\"version\"):.*/\1: \"$NEW_VERSION\",/" vss-extension.json
 # Update tasks versions to the same version
 sed -i -E -e "s/(\"Major\"):.*/\1: $MAJOR,/" -e "s/(\"Minor\"):.*/\1: $MINOR,/" -e "s/(\"Patch\"):.*/\1: $PATCH/" */task.json
 
+# Update major version in e2e-pipeline.yml if it's a major version bump
+if [ "$1" == "major" ]; then
+  sed -i -E "s/SyntheticsRunTests@[0-9]+/SyntheticsRunTests@$MAJOR/" .azure-pipelines/e2e-pipeline.yml
+fi
+
 echo $NEW_VERSION 


### PR DESCRIPTION
- https://github.com/DataDog/datadog-ci-azure-devops/pull/217 (← **you are here**)
- https://github.com/DataDog/datadog-ci-azure-devops/pull/215

Mock `getOrgSettings` so it doesn't fail and retry 3 times, speeding up test scenarios.