### PR TITLE
Remove default value for `files`

### DIFF
--- a/SyntheticsRunTestsTask/task.json
+++ b/SyntheticsRunTestsTask/task.json
@@ -92,7 +92,7 @@
       "name": "files",
       "type": "multiLine",
       "label": "Synthetic test config files",
-      "defaultValue": "{,!(node_modules)/**/}*.synthetics.json",
+      "defaultValue": "",
       "helpMarkDown": "Glob pattern to detect Synthetic tests config files."
     },
     {


### PR DESCRIPTION
In Azure DevOps, the default value is not only there for documentation: it's actually used as a fallback. This means that although the user didn't provide any `files` input, we are still asking datadog-ci to perform a glob file search.