### PR TITLE
[chores] Bump pinned e2e task version on major bump

### DIFF
--- a/.azure-pipelines/dev-pipeline.yml
+++ b/.azure-pipelines/dev-pipeline.yml
@@ -45,7 +45,7 @@ stages:
           - task: NodeTool@0
             displayName: Install Node.js
             inputs:
-              versionSpec: '16.15.0'
+              versionSpec: '20.11.0'
 
           - task: Bash@3
             displayName: Compile the Synthetics task

--- a/.azure-pipelines/e2e-pipeline.yml
+++ b/.azure-pipelines/e2e-pipeline.yml
@@ -27,7 +27,7 @@ stages:
         pool:
           vmImage: $(imageName)
         steps:
-          - task: Datadog.datadog-ci-dev.synthetics-application-testing.SyntheticsRunTests@1
+          - task: Datadog.datadog-ci-dev.synthetics-application-testing.SyntheticsRunTests@2
             displayName: Run DEV task - apiAppKeys
             inputs:
               authenticationType: 'apiAppKeys'
@@ -36,7 +36,7 @@ stages:
               publicIds: '2r9-q7u-4nn,pwd-mwg-3p5'
               configPath: 'ci/e2e.config.json'
 
-          - task: Datadog.datadog-ci-dev.synthetics-application-testing.SyntheticsRunTests@1
+          - task: Datadog.datadog-ci-dev.synthetics-application-testing.SyntheticsRunTests@2
             displayName: Run DEV task - connectedService
             inputs:
               authenticationType: 'connectedService'

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -40,7 +40,7 @@ stages:
           - task: NodeTool@0
             displayName: Install Node.js
             inputs:
-              versionSpec: '16.15.0'
+              versionSpec: '20.11.0'
 
           - task: Bash@3
             displayName: Compile the Synthetics task

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,7 +5,7 @@ name: Run unit tests
 on: push
 
 jobs:
-  build-and-test-synthetics:
+  build-and-test:
     name: Build and test SyntheticsRunTestsTask
     runs-on: ubuntu-latest
 
@@ -23,4 +23,4 @@ jobs:
       - run: yarn lint
       - run: yarn build && yarn test
         env:
-          FORCE_COLOR: '1'
+          FORCE_COLOR: 1

--- a/ci/increment-version.sh
+++ b/ci/increment-version.sh
@@ -28,4 +28,9 @@ sed -i -E "s/(\"version\"):.*/\1: \"$NEW_VERSION\",/" vss-extension.json
 # Update tasks versions to the same version
 sed -i -E -e "s/(\"Major\"):.*/\1: $MAJOR,/" -e "s/(\"Minor\"):.*/\1: $MINOR,/" -e "s/(\"Patch\"):.*/\1: $PATCH/" */task.json
 
+# Update major version in e2e-pipeline.yml if it's a major version bump
+if [ "$1" == "major" ]; then
+  sed -i -E "s/SyntheticsRunTests@[0-9]+/SyntheticsRunTests@$MAJOR/" .azure-pipelines/e2e-pipeline.yml
+fi
+
 echo $NEW_VERSION 


### PR DESCRIPTION
This PR makes sure we bump the referenced task version in e2e tests when doing a major bump on the integration. Otherwise, we'd still target the old major version.

This PR also does a few clean ups.