### PR TITLE
[ci] Fix flaky e2e test on Windows

### DIFF
--- a/.azure-pipelines/e2e-pipeline.yml
+++ b/.azure-pipelines/e2e-pipeline.yml
@@ -45,8 +45,8 @@ stages:
             displayName: Example of using outputs (Linux)
             condition: eq(variables['Agent.OS'], 'Linux')
           - powershell: |
-              echo 'Batch URL: $(runSyntheticsTests.batchUrl)'
-              echo 'Raw Results:'
+              echo "Batch URL: $(runSyntheticsTests.batchUrl)"
+              echo "Raw Results:"
               echo $Env:RAW_RESULTS | jq '.'
             displayName: Example of using outputs (Windows)
             condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/.azure-pipelines/e2e-pipeline.yml
+++ b/.azure-pipelines/e2e-pipeline.yml
@@ -38,11 +38,20 @@ stages:
               configPath: 'ci/e2e.config.json'
 
           # Example of using outputs
-          - script: |
+          - bash: |
               echo 'Batch URL: $(runSyntheticsTests.batchUrl)'
               echo 'Raw Results:'
               echo '$(runSyntheticsTests.rawResults)' | jq '.'
-            displayName: Example of using outputs
+            displayName: Example of using outputs (Linux)
+            condition: eq(variables['Agent.OS'], 'Linux')
+          - powershell: |
+              echo 'Batch URL: $(runSyntheticsTests.batchUrl)'
+              echo 'Raw Results:'
+              echo $Env:RAW_RESULTS | jq '.'
+            displayName: Example of using outputs (Windows)
+            condition: eq(variables['Agent.OS'], 'Windows_NT')
+            env:
+              RAW_RESULTS: $(runSyntheticsTests.rawResults)
 
           # Example of parsing and using raw results with JS
           - task: NodeTool@0


### PR DESCRIPTION
This PR splits the "Example of using outputs" e2e step into 2 different implementations that are OS-specific.

Since the `rawResults` output is a JSON string which has a varying size based on a lot of factors, the "Example of using outputs" e2e step was flaky, and failed today with:
<img width="894" alt="image" src="https://github.com/user-attachments/assets/ce8ac2c5-a867-44da-822c-fc3e4664a912" />

On Linux the command line length limit is huge (~1 or 2 millions of characters) but it's 8191 on Windows.

So the solution is to store the `$(runSyntheticsTests.rawResults)` inside an env var that can be used later in the powershell script. I preferred to keep the original example for Linux because it works with less code.
