### PR TITLE
chore: disable automated dependency updater config [incident-51602]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
-# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+# # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
 
-version: 2
-updates:
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    schedule:
-      # Check for updates to GitHub Actions every week
-      interval: 'weekly'
+# version: 2
+# updates:
+#   - package-ecosystem: 'github-actions'
+#     directory: '/'
+#     schedule:
+#       # Check for updates to GitHub Actions every week
+#       interval: 'weekly'


### PR DESCRIPTION
As part of #incident-51602, we are temporarily disabling all automated dependency updaters to reduce exposure to potential zero-day vulnerabilities in recent releases.

This PR disables the Dependabot/Renovate configuration not managed by ADMS by commenting out (YAML) or renaming (JSON) the config file. Please do not re-enable until further notice.